### PR TITLE
Feat: Vertex AI support and Multi-Lang

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,6 @@
+# Groq provider (default)
 GROQ_API_KEY=your_groq_api_key_here
+
+# Vertex AI provider — uses gcloud ADC by default
+# Override the credentials path if needed:
+# GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Audio Input — Press a hotkey. Speak. Text appears — anywhere.</title>
-  <meta name="description" content="Global hotkey voice transcription for macOS. Powered by Groq Whisper, polished by AI. Free, open source, BYOK." />
+  <meta name="description" content="Global hotkey voice transcription for macOS. Choose Groq Whisper or Google Vertex AI Gemini. AI-polished, multi-language, open source." />
   <meta property="og:title" content="Audio Input — Voice input for every app on macOS" />
-  <meta property="og:description" content="Press ⌘⇧Space, speak, text appears. AI-polished. Free & open source." />
+  <meta property="og:description" content="Press ⌘⇧Space, speak, text appears. Groq or Vertex AI. AI-polished. Free & open source." />
   <meta property="og:type" content="website" />
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -66,9 +66,7 @@
       gap: 0.5rem;
     }
 
-    .nav-logo svg {
-      color: var(--accent);
-    }
+    .nav-logo svg { color: var(--accent); }
 
     .nav-links {
       display: flex;
@@ -146,7 +144,7 @@
     .subtitle {
       font-size: 1.1rem;
       color: var(--muted);
-      max-width: 480px;
+      max-width: 520px;
       margin: 0 auto 3rem;
       line-height: 1.65;
     }
@@ -201,7 +199,6 @@
       gap: 1.1rem;
     }
 
-    /* Step rows */
     .demo-row {
       display: flex;
       align-items: center;
@@ -246,7 +243,6 @@
       letter-spacing: 0.01em;
     }
 
-    /* Waveform animation */
     .waveform {
       display: flex;
       align-items: center;
@@ -293,7 +289,6 @@
       50%       { opacity: 0.6; transform: scale(0.85); }
     }
 
-    /* Typewriter text */
     .demo-output {
       color: var(--text);
       overflow: hidden;
@@ -412,9 +407,7 @@
       margin-bottom: 3rem;
     }
 
-    .features-header .section-sub {
-      margin: 0 auto;
-    }
+    .features-header .section-sub { margin: 0 auto; }
 
     .feat-grid {
       display: grid;
@@ -459,6 +452,72 @@
       line-height: 1.55;
     }
 
+    /* ── PROVIDERS SECTION ── */
+    .providers-section { border-top: 1px solid var(--border); }
+
+    .provider-cards {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1.25rem;
+      margin-top: 2.5rem;
+    }
+
+    .prov-card {
+      background: var(--surface);
+      border: 1px solid var(--border-hi);
+      border-radius: 14px;
+      padding: 2rem;
+      transition: border-color 0.15s;
+    }
+    .prov-card:hover { border-color: var(--accent); }
+
+    .prov-card-header {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 1rem;
+    }
+
+    .prov-icon {
+      width: 40px;
+      height: 40px;
+      border-radius: 10px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+
+    .prov-icon.groq { background: rgba(255,165,0,0.12); border: 1px solid rgba(255,165,0,0.25); color: #ffa500; }
+    .prov-icon.vertex { background: rgba(66,133,244,0.12); border: 1px solid rgba(66,133,244,0.25); color: #4285f4; }
+
+    .prov-name { font-size: 1.1rem; font-weight: 600; }
+    .prov-tag { font-size: 0.72rem; color: var(--dim); margin-top: 0.15rem; }
+
+    .prov-card ul {
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .prov-card li {
+      font-size: 0.85rem;
+      color: var(--muted);
+      display: flex;
+      align-items: flex-start;
+      gap: 0.6rem;
+      line-height: 1.5;
+    }
+
+    .prov-card li::before {
+      content: "✓";
+      color: var(--green);
+      font-weight: 600;
+      flex-shrink: 0;
+      margin-top: 0.05rem;
+    }
+
     /* ── INSTALL SECTION ── */
     .install-section .section-inner {
       display: grid;
@@ -483,10 +542,7 @@
       gap: 0.5rem;
     }
 
-    .code-header-dots {
-      display: flex;
-      gap: 5px;
-    }
+    .code-header-dots { display: flex; gap: 5px; }
 
     .ch-dot {
       width: 9px;
@@ -512,7 +568,6 @@
     .code-line { display: flex; gap: 0.75rem; }
     .code-ps { color: var(--dim); user-select: none; }
     .code-cmd { color: var(--text); }
-    .code-comment { color: var(--dim); font-style: italic; }
 
     .install-alt {
       margin-top: 1rem;
@@ -522,22 +577,45 @@
     }
 
     /* ── SETUP STEPS ── */
-    .setup-section {
-      border-top: 1px solid var(--border);
-    }
+    .setup-section { border-top: 1px solid var(--border); }
 
     .setup-section .section-inner {
-      max-width: 600px;
+      max-width: 620px;
       margin: 0 auto;
       text-align: center;
     }
+
+    .setup-tabs {
+      display: inline-flex;
+      gap: 0;
+      background: var(--surface);
+      border: 1px solid var(--border-hi);
+      border-radius: 10px;
+      padding: 3px;
+      margin: 2rem auto 0;
+    }
+
+    .setup-tab {
+      padding: 0.5rem 1.5rem;
+      border: none;
+      border-radius: 8px;
+      background: transparent;
+      color: var(--muted);
+      font-size: 0.85rem;
+      font-weight: 500;
+      cursor: pointer;
+      font-family: -apple-system, BlinkMacSystemFont, "Inter", sans-serif;
+      transition: all 0.2s;
+    }
+    .setup-tab:hover { color: var(--text); }
+    .setup-tab.active { background: var(--accent-glow); color: var(--accent); border: 1px solid rgba(124,111,255,0.3); }
 
     .steps {
       display: flex;
       flex-direction: column;
       gap: 0.75rem;
       text-align: left;
-      margin-top: 2.5rem;
+      margin-top: 1.5rem;
     }
 
     .step {
@@ -579,9 +657,9 @@
       line-height: 1.5;
     }
 
-    .step-body a {
-      color: var(--accent);
-    }
+    .step-body a { color: var(--accent); }
+
+    .hidden { display: none !important; }
 
     /* ── FOOTER ── */
     footer {
@@ -619,6 +697,8 @@
         gap: 2rem;
       }
 
+      .provider-cards { grid-template-columns: 1fr; }
+
       .install-strip {
         flex-direction: column;
         width: 100%;
@@ -645,6 +725,7 @@
   </div>
   <div class="nav-links">
     <a href="#features" class="hide-sm">Features</a>
+    <a href="#providers" class="hide-sm">Providers</a>
     <a href="#install" class="hide-sm">Install</a>
     <a href="#setup" class="hide-sm">Setup</a>
     <a href="https://github.com/tonyyun/audio-input" class="nav-gh">
@@ -660,14 +741,15 @@
 <section class="hero">
   <div class="badge">
     <span class="badge-dot"></span>
-    Free &amp; Open Source &middot; macOS
+    v0.3.5 &middot; Free &amp; Open Source &middot; macOS
   </div>
 
   <h1>Press a hotkey. Speak.<br /><em>Text appears&nbsp;&mdash; anywhere.</em></h1>
 
   <p class="subtitle">
     Global hotkey voice input for every app on macOS.
-    Open source, no account, no telemetry. Your API key&nbsp;&mdash; your data.
+    Choose between Groq Whisper or Google Vertex AI.
+    Open source, no telemetry, extensible.
   </p>
 
   <!-- Animated demo terminal -->
@@ -680,7 +762,6 @@
         <span class="tbar-title">Audio Input</span>
       </div>
       <div class="demo-body">
-
         <div class="demo-row">
           <span class="demo-label">Hotkey</span>
           <span class="demo-key">
@@ -690,32 +771,21 @@
           </span>
           <span style="color:var(--dim);font-size:0.78rem;margin-left:auto;">Hold to record</span>
         </div>
-
         <div class="demo-row">
           <span class="demo-label">Recording</span>
           <span class="mic-dot"></span>
           <div class="waveform">
-            <div class="wave-bar"></div>
-            <div class="wave-bar"></div>
-            <div class="wave-bar"></div>
-            <div class="wave-bar"></div>
-            <div class="wave-bar"></div>
-            <div class="wave-bar"></div>
-            <div class="wave-bar"></div>
-            <div class="wave-bar"></div>
-            <div class="wave-bar"></div>
-            <div class="wave-bar"></div>
-            <div class="wave-bar"></div>
-            <div class="wave-bar"></div>
+            <div class="wave-bar"></div><div class="wave-bar"></div><div class="wave-bar"></div>
+            <div class="wave-bar"></div><div class="wave-bar"></div><div class="wave-bar"></div>
+            <div class="wave-bar"></div><div class="wave-bar"></div><div class="wave-bar"></div>
+            <div class="wave-bar"></div><div class="wave-bar"></div><div class="wave-bar"></div>
           </div>
           <span style="color:var(--dim);font-size:0.78rem;margin-left:auto;">Release to send</span>
         </div>
-
         <div class="demo-row">
           <span class="demo-label">Output</span>
           <span class="demo-output">Transcribed and polished by AI.</span>
         </div>
-
       </div>
     </div>
   </div>
@@ -752,7 +822,7 @@
           </svg>
         </div>
         <h3>Works Everywhere</h3>
-        <p>Injects text directly into any focused input via macOS Accessibility API. Slack, Notion, Terminal, browsers — anywhere.</p>
+        <p>Injects text directly into any focused input via macOS Accessibility API. Slack, Notion, Terminal, browsers &mdash; anywhere.</p>
       </div>
 
       <div class="feat-card">
@@ -764,7 +834,18 @@
           </svg>
         </div>
         <h3>AI-Powered Polish</h3>
-        <p>An optional LLM pass removes filler words, fixes punctuation, and cleans up sentence flow. Screenshot context makes it smarter.</p>
+        <p>An optional LLM pass removes filler words, fixes punctuation, and cleans up sentence flow. Screenshot context makes it even smarter.</p>
+      </div>
+
+      <div class="feat-card">
+        <div class="feat-icon">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/>
+            <polyline points="22,6 12,13 2,6"/>
+          </svg>
+        </div>
+        <h3>Multi-Provider</h3>
+        <p>Groq Whisper (free API key) or Google Vertex AI Gemini (enterprise ADC). Switch providers with one click. Extensible to new providers.</p>
       </div>
 
       <div class="feat-card">
@@ -774,19 +855,20 @@
             <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
           </svg>
         </div>
-        <h3>Privacy First (BYOK)</h3>
-        <p>Bring Your Own API Key. Audio goes directly to Groq &mdash; no server of ours ever sees it. Unlike closed-source alternatives, you can read every line of code.</p>
+        <h3>Privacy First</h3>
+        <p>Audio goes directly to your chosen provider &mdash; no intermediary server. Fully open source, BYOK. You own your data.</p>
       </div>
 
       <div class="feat-card">
         <div class="feat-icon">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/>
-            <polyline points="13 2 13 9 20 9"/>
+            <circle cx="12" cy="12" r="10"/>
+            <line x1="2" y1="12" x2="22" y2="12"/>
+            <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
           </svg>
         </div>
         <h3>50+ Languages</h3>
-        <p>Powered by Whisper large-v3-turbo. Chinese, English, Japanese, Korean, Spanish and more — auto-detected.</p>
+        <p>Whisper large-v3-turbo and Gemini handle Chinese, English, Japanese, Korean, Spanish, and many more &mdash; auto-detected.</p>
       </div>
 
       <div class="feat-card">
@@ -802,15 +884,83 @@
       <div class="feat-card">
         <div class="feat-icon">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="12" cy="12" r="10"/>
-            <line x1="2" y1="12" x2="22" y2="12"/>
-            <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+            <path d="M5 8l6 6"/>
+            <path d="M4 14l6-6 2-3"/>
+            <path d="M2 5h12"/>
+            <path d="M7 2h1"/>
+            <path d="M22 22l-5-10-5 10"/>
+            <path d="M14 18h6"/>
+          </svg>
+        </div>
+        <h3>English &amp; 中文 UI</h3>
+        <p>Interface defaults to English with one-click switch to Chinese. Language preference persists across restarts.</p>
+      </div>
+
+      <div class="feat-card">
+        <div class="feat-icon">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/>
           </svg>
         </div>
         <h3>Open Source</h3>
-        <p>MIT licensed. Audit the code, fork it, extend it. No subscription, no upsell. A better alternative to SuperWhisper.</p>
+        <p>MIT licensed. Audit the code, fork it, add your own provider. No subscription, no upsell.</p>
       </div>
 
+    </div>
+  </div>
+</section>
+
+<!-- PROVIDERS -->
+<section class="providers-section" id="providers">
+  <div class="section-inner">
+    <div style="text-align:center;margin-bottom:0.5rem;">
+      <p class="section-label">Providers</p>
+      <h2 class="section-title">Your cloud, your choice</h2>
+      <p class="section-sub" style="margin:0 auto;">Switch providers any time. Adding a new one takes 3 files.</p>
+    </div>
+
+    <div class="provider-cards">
+      <div class="prov-card">
+        <div class="prov-card-header">
+          <div class="prov-icon groq">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
+            </svg>
+          </div>
+          <div>
+            <div class="prov-name">Groq</div>
+            <div class="prov-tag">Free API Key</div>
+          </div>
+        </div>
+        <ul>
+          <li>Whisper large-v3-turbo transcription</li>
+          <li>LLaMA-based AI polish</li>
+          <li>Free tier &mdash; generous for daily use</li>
+          <li>Sign up at <a href="https://console.groq.com">console.groq.com</a></li>
+        </ul>
+      </div>
+
+      <div class="prov-card">
+        <div class="prov-card-header">
+          <div class="prov-icon vertex">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round">
+              <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/>
+              <polyline points="3.27 6.96 12 12.01 20.73 6.96" stroke-linecap="round"/>
+              <line x1="12" y1="22.08" x2="12" y2="12" stroke-linecap="round"/>
+            </svg>
+          </div>
+          <div>
+            <div class="prov-name">Vertex AI</div>
+            <div class="prov-tag">Google Cloud</div>
+          </div>
+        </div>
+        <ul>
+          <li>Gemini 2.5 Flash / Pro transcription</li>
+          <li>Multimodal polish with screenshot context</li>
+          <li>No API key &mdash; uses <code style="background:var(--surface-hi);padding:0.1rem 0.35rem;border-radius:3px;font-size:0.82rem;color:var(--muted);">gcloud</code> ADC</li>
+          <li>Enterprise-grade for teams already on GCP</li>
+        </ul>
+      </div>
     </div>
   </div>
 </section>
@@ -859,43 +1009,61 @@
   <div class="section-inner">
     <p class="section-label">Setup</p>
     <h2 class="section-title">Up and running in 3 steps</h2>
-    <p class="section-sub" style="margin:0 auto;">No account needed. Just a free API key.</p>
+    <p class="section-sub" style="margin:0 auto;">Pick a provider and start talking.</p>
 
-    <div class="steps">
+    <div class="setup-tabs">
+      <button class="setup-tab active" onclick="switchSetup('groq')">Groq (Free)</button>
+      <button class="setup-tab" onclick="switchSetup('vertex')">Vertex AI</button>
+    </div>
 
+    <!-- Groq steps -->
+    <div class="steps" id="steps-groq">
       <div class="step">
         <div class="step-num">1</div>
         <div class="step-body">
           <h4>Get a free Groq API key</h4>
-          <p>
-            Sign up at <a href="https://console.groq.com" target="_blank" rel="noopener">console.groq.com</a>.
-            The free tier is generous enough for daily use.
-          </p>
+          <p>Sign up at <a href="https://console.groq.com" target="_blank" rel="noopener">console.groq.com</a>. The free tier is generous enough for daily use.</p>
         </div>
       </div>
-
       <div class="step">
         <div class="step-num">2</div>
         <div class="step-body">
-          <h4>Set your key in the app</h4>
-          <p>
-            Launch Audio Input. Right-click the menu bar icon
-            and choose <strong>Configure API Key</strong>, then paste your Groq key.
-          </p>
+          <h4>Paste your key in the app</h4>
+          <p>Launch Audio Input, select <strong>Groq</strong> as your provider, and paste the API key. Done.</p>
         </div>
       </div>
-
       <div class="step">
         <div class="step-num">3</div>
         <div class="step-body">
           <h4>Press <kbd style="background:var(--surface-hi);border:1px solid var(--border-hi);border-radius:4px;padding:0.1rem 0.4rem;font-family:var(--mono);font-size:0.85rem;">&#8984;&#8679;Space</kbd> and speak</h4>
-          <p>
-            Hold the hotkey, dictate, release. Your words appear at the cursor in
-            any app &mdash; polished and ready.
-          </p>
+          <p>Hold the hotkey, dictate, release. Your words appear at the cursor &mdash; polished and ready.</p>
         </div>
       </div>
+    </div>
 
+    <!-- Vertex AI steps -->
+    <div class="steps hidden" id="steps-vertex">
+      <div class="step">
+        <div class="step-num">1</div>
+        <div class="step-body">
+          <h4>Authenticate with gcloud</h4>
+          <p>Run <code style="background:var(--surface-hi);padding:0.15rem 0.4rem;border-radius:4px;font-family:var(--mono);font-size:0.82rem;color:var(--muted);">gcloud auth application-default login</code> in your terminal. No API key needed.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">2</div>
+        <div class="step-body">
+          <h4>Select Vertex AI and enter your project</h4>
+          <p>Launch Audio Input, switch to <strong>Vertex AI</strong>, enter your GCP project ID, and pick a Gemini model.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">3</div>
+        <div class="step-body">
+          <h4>Press <kbd style="background:var(--surface-hi);border:1px solid var(--border-hi);border-radius:4px;padding:0.1rem 0.4rem;font-family:var(--mono);font-size:0.85rem;">&#8984;&#8679;Space</kbd> and speak</h4>
+          <p>Hold the hotkey, dictate, release. Gemini transcribes and polishes your words in one pass.</p>
+        </div>
+      </div>
     </div>
   </div>
 </section>
@@ -906,11 +1074,13 @@
     <a href="https://github.com/tonyyun/audio-input">GitHub</a>
     <a href="https://github.com/tonyyun/audio-input/releases">Releases</a>
     <a href="https://github.com/tonyyun/audio-input/issues">Issues</a>
+    <a href="https://github.com/tonyyun/audio-input/blob/main/PRIVACY.md">Privacy</a>
     <a href="https://github.com/tonyyun/audio-input/blob/main/LICENSE">MIT License</a>
   </div>
   <div>
     Audio Input &middot; Built with Tauri + Rust + Svelte &middot; Powered by
-    <a href="https://groq.com" target="_blank" rel="noopener">Groq</a> Whisper
+    <a href="https://groq.com" target="_blank" rel="noopener">Groq</a> Whisper &amp;
+    <a href="https://cloud.google.com/vertex-ai" target="_blank" rel="noopener">Vertex AI</a> Gemini
   </div>
 </footer>
 
@@ -928,6 +1098,14 @@
     });
   }
 
+  function switchSetup(provider) {
+    document.querySelectorAll('.setup-tab').forEach(t => t.classList.remove('active'));
+    document.querySelectorAll('.steps').forEach(s => s.classList.add('hidden'));
+
+    event.target.classList.add('active');
+    document.getElementById('steps-' + provider).classList.remove('hidden');
+  }
+
   // Restart the typing animation when the demo scrolls into view
   (function () {
     const output = document.querySelector('.demo-output');
@@ -936,7 +1114,6 @@
     const observer = new IntersectionObserver((entries) => {
       entries.forEach(entry => {
         if (entry.isIntersecting) {
-          // Replay animations by toggling a class
           const rows = document.querySelectorAll('.demo-row');
           rows.forEach(r => { r.style.animation = 'none'; r.offsetHeight; r.style.animation = ''; });
           output.style.animation = 'none';

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Audio Input — Press a hotkey. Speak. Text appears — anywhere.</title>
-  <meta name="description" content="Global hotkey voice transcription for macOS. Choose Groq Whisper or Google Vertex AI Gemini. AI-polished, multi-language, open source." />
-  <meta property="og:title" content="Audio Input — Voice input for every app on macOS" />
-  <meta property="og:description" content="Press ⌘⇧Space, speak, text appears. Groq or Vertex AI. AI-polished. Free & open source." />
+  <meta name="description" content="Global hotkey voice transcription for macOS & Windows. Choose Groq Whisper or Google Vertex AI Gemini. AI-polished, multi-language, open source." />
+  <meta property="og:title" content="Audio Input — Voice input for every app on macOS & Windows" />
+  <meta property="og:description" content="Press a hotkey, speak, text appears at cursor. Groq or Vertex AI. macOS & Windows. Free & open source." />
   <meta property="og:type" content="website" />
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -741,13 +741,13 @@
 <section class="hero">
   <div class="badge">
     <span class="badge-dot"></span>
-    v0.3.5 &middot; Free &amp; Open Source &middot; macOS
+    v0.3.5 &middot; Free &amp; Open Source &middot; macOS &amp; Windows
   </div>
 
   <h1>Press a hotkey. Speak.<br /><em>Text appears&nbsp;&mdash; anywhere.</em></h1>
 
   <p class="subtitle">
-    Global hotkey voice input for every app on macOS.
+    Global hotkey voice input for every app on macOS and Windows.
     Choose between Groq Whisper or Google Vertex AI.
     Open source, no telemetry, extensible.
   </p>
@@ -798,7 +798,7 @@
       <button class="copy-btn" id="copyBtn" onclick="copyCmd()">Copy</button>
     </div>
     <p class="alt-link">
-      or <a href="https://github.com/tonyyun/audio-input/releases">download the .dmg</a> &middot; Requires macOS Ventura+
+      or <a href="https://github.com/tonyyun/audio-input/releases">download from Releases</a> &middot; macOS Ventura+ &middot; Windows 10+
     </p>
   </div>
 </section>
@@ -822,7 +822,7 @@
           </svg>
         </div>
         <h3>Works Everywhere</h3>
-        <p>Injects text directly into any focused input via macOS Accessibility API. Slack, Notion, Terminal, browsers &mdash; anywhere.</p>
+        <p>Injects text directly into any focused input. macOS Accessibility API and Windows key simulation. Slack, Notion, Terminal, browsers &mdash; anywhere.</p>
       </div>
 
       <div class="feat-card">
@@ -972,8 +972,7 @@
       <p class="section-label">Install</p>
       <h2 class="section-title">One command<br />to get started</h2>
       <p class="section-sub" style="margin-top:0.75rem;">
-        Install via Homebrew or grab the signed .dmg from GitHub Releases.
-        macOS Ventura (13+) required.
+        Install via Homebrew on macOS, or grab the installer from GitHub Releases for macOS &amp; Windows.
       </p>
     </div>
 
@@ -999,6 +998,10 @@
         <a href="https://github.com/tonyyun/audio-input/releases" style="color:var(--accent);">
           GitHub Releases &rarr;
         </a>
+      </p>
+      <p class="install-alt" style="margin-top:0.5rem;">
+        <strong style="color:var(--text);">Windows:</strong> Download the <code style="background:var(--surface-hi);padding:0.1rem 0.35rem;border-radius:3px;font-size:0.82rem;color:var(--muted);">.msi</code> installer from
+        <a href="https://github.com/tonyyun/audio-input/releases" style="color:var(--accent);">Releases</a>. Windows 10+ required.
       </p>
     </div>
   </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "audio-input",
-  "version": "0.1.0",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "audio-input",
-      "version": "0.1.0",
+      "version": "0.3.5",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-global-shortcut": "^2",
@@ -820,7 +820,6 @@
       "integrity": "sha512-Txsm1tJvtiYeLUVRNqxZGKR/mI+CzuIQuc2gn+YCs9rMTowpNZ2Nqt53JdL8KF9bLhAf2ruR/dr9eZCwdTriRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^2.1.0",
         "debug": "^4.3.4",
@@ -1440,7 +1439,6 @@
       "integrity": "sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -1494,7 +1492,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "audio-input",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -251,7 +251,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "audio-input"
-version = "0.2.0"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audio-input"
-version = "0.2.0"
+version = "0.3.5"
 edition = "2021"
 
 [lib]

--- a/src-tauri/src/audio/encoder.rs
+++ b/src-tauri/src/audio/encoder.rs
@@ -5,17 +5,17 @@ use tracing::info;
 
 const TARGET_SAMPLE_RATE: u32 = 16000;
 
-/// 将录音采样数据编码为 WAV bytes（16kHz, 单声道, 16-bit PCM）
-/// Whisper 的最优输入格式
+/// Encode audio samples to WAV bytes (16kHz, mono, 16-bit PCM)
+/// Optimal input format for Whisper
 pub fn encode_wav(samples: &[f32], source_rate: u32, source_channels: u16) -> Result<Vec<u8>> {
-    // 下混到单声道
+    // Downmix to mono
     let mono = if source_channels > 1 {
         downsample_to_mono(samples, source_channels)
     } else {
         samples.to_vec()
     };
 
-    // 重采样到 16kHz
+    // Resample to 16kHz
     let resampled = if source_rate != TARGET_SAMPLE_RATE {
         resample(&mono, source_rate, TARGET_SAMPLE_RATE)
     } else {
@@ -23,7 +23,7 @@ pub fn encode_wav(samples: &[f32], source_rate: u32, source_channels: u16) -> Re
     };
 
     info!(
-        "编码 WAV: {} 采样点 @ {}Hz → {} 采样点 @ {}Hz",
+        "Encoding WAV: {} samples @ {}Hz → {} samples @ {}Hz",
         samples.len(),
         source_rate,
         resampled.len(),
@@ -58,7 +58,7 @@ fn downsample_to_mono(samples: &[f32], channels: u16) -> Vec<f32> {
         .collect()
 }
 
-/// 线性插值重采样
+/// Linear interpolation resampling
 fn resample(samples: &[f32], from_rate: u32, to_rate: u32) -> Vec<f32> {
     if from_rate == to_rate {
         return samples.to_vec();

--- a/src-tauri/src/audio/recorder.rs
+++ b/src-tauri/src/audio/recorder.rs
@@ -29,7 +29,7 @@ pub fn list_input_devices() -> Vec<String> {
             .filter_map(|d| d.name().ok())
             .collect(),
         Err(e) => {
-            warn!("列举输入设备失败: {}", e);
+            warn!("Failed to list input devices: {}", e);
             Vec::new()
         }
     }
@@ -63,29 +63,29 @@ impl Recorder {
                 .and_then(|mut devs| devs.find(|d| d.name().as_deref().ok() == Some(name.as_str())));
 
             if let Some(d) = found {
-                info!("使用配置录音设备: {}", name);
+                info!("Using configured recording device: {}", name);
                 d
             } else {
-                warn!("配置的设备 '{}' 不可用，回退到默认设备", name);
+                warn!("Configured device '{}' unavailable, falling back to default", name);
                 host.default_input_device()
-                    .context("找不到默认麦克风设备")?
+                    .context("No default microphone found")?
             }
         } else {
             host.default_input_device()
-                .context("找不到默认麦克风设备")?
+                .context("No default microphone found")?
         };
 
-        info!("使用录音设备: {}", device.name().unwrap_or_default());
+        info!("Using recording device: {}", device.name().unwrap_or_default());
 
         let config = device
             .default_input_config()
-            .context("无法获取默认录音配置")?;
+            .context("Cannot get default recording config")?;
 
         self.sample_rate = config.sample_rate().0;
         self.channels = config.channels();
 
         info!(
-            "录音配置: {}Hz, {} 声道, {:?}",
+            "Recording config: {}Hz, {} channels, {:?}",
             self.sample_rate,
             self.channels,
             config.sample_format()
@@ -101,26 +101,26 @@ impl Recorder {
             SampleFormat::F32 => build_stream::<f32>(&device, &config.into(), buffer)?,
             SampleFormat::I16 => build_stream_i16(&device, &config.into(), buffer)?,
             SampleFormat::U16 => build_stream_u16(&device, &config.into(), buffer)?,
-            fmt => anyhow::bail!("不支持的音频格式: {:?}", fmt),
+            fmt => anyhow::bail!("Unsupported audio format: {:?}", fmt),
         };
 
-        stream.play().context("无法启动录音流")?;
+        stream.play().context("Failed to start recording stream")?;
         self.stream = Some(SendStream(stream));
-        info!("录音已开始");
+        info!("Recording started");
         Ok(())
     }
 
     pub fn stop(&mut self) -> Result<AudioData> {
         // Drop the stream to stop recording
         self.stream.take();
-        info!("录音已停止");
+        info!("Recording stopped");
 
         let samples = {
             let buf = self.buffer.lock().unwrap();
             buf.clone()
         };
 
-        info!("录制了 {} 个采样点 ({:.1}秒)", samples.len(), samples.len() as f32 / self.sample_rate as f32);
+        info!("Recorded {} samples ({:.1}s)", samples.len(), samples.len() as f32 / self.sample_rate as f32);
 
         Ok(AudioData {
             samples,
@@ -147,7 +147,7 @@ where
                 buf.push(<f32 as FromSample<T>>::from_sample_(sample));
             }
         },
-        move |err| error!("录音错误: {}", err),
+        move |err| error!("Recording error: {}", err),
         None,
     )?;
     Ok(stream)
@@ -166,7 +166,7 @@ fn build_stream_i16(
                 buf.push(sample as f32 / i16::MAX as f32);
             }
         },
-        move |err| error!("录音错误: {}", err),
+        move |err| error!("Recording error: {}", err),
         None,
     )?;
     Ok(stream)
@@ -186,7 +186,7 @@ fn build_stream_u16(
                 buf.push((sample as f32 - 32768.0) / 32768.0);
             }
         },
-        move |err| error!("录音错误: {}", err),
+        move |err| error!("Recording error: {}", err),
         None,
     )?;
     Ok(stream)

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,6 +1,6 @@
 use crate::{
     audio::{encode_wav, Recorder},
-    config::{AppConfig, Provider},
+    config::AppConfig,
     input::inject_text,
     screenshot::capture_primary_screen,
     state::{AppState, ScreenshotState, SharedState},
@@ -13,8 +13,10 @@ use tracing::{error, info, warn};
 
 pub struct RecorderState(pub Arc<Mutex<Recorder>>);
 
-/// 切换录音状态（Toggle 模式）
-/// Idle → Recording → (自动) → Processing → Idle
+// ---------------------------------------------------------------------------
+// Toggle recording (unchanged API)
+// ---------------------------------------------------------------------------
+
 pub async fn toggle_recording<R: Runtime>(
     app: AppHandle<R>,
     shared_state: SharedState,
@@ -36,7 +38,6 @@ pub async fn toggle_recording<R: Runtime>(
             warn!("正在处理中，请稍候");
         }
         AppState::Error(_) => {
-            // 从错误状态恢复，允许重新开始
             let mut state = shared_state.lock().unwrap();
             *state = AppState::Idle;
             set_tray_icon(&app, "idle");
@@ -52,7 +53,6 @@ async fn start_recording<R: Runtime>(
 ) {
     info!("开始录音...");
 
-    // Start recorder first — screenshot must not block this.
     let result = {
         match recorder_state.lock() {
             Ok(mut recorder) => recorder.start(app),
@@ -72,7 +72,6 @@ async fn start_recording<R: Runtime>(
             let _ = app.emit("state-change", "recording");
             info!("状态 → Recording");
 
-            // Spawn screenshot AFTER HUD has rendered.
             let screenshot_context_enabled = {
                 let config = app.state::<Arc<Mutex<AppConfig>>>();
                 let enabled = config.lock().unwrap().screenshot_context_enabled;
@@ -81,7 +80,6 @@ async fn start_recording<R: Runtime>(
             let ss = app.state::<ScreenshotState>().inner().clone();
             if screenshot_context_enabled {
                 tokio::spawn(async move {
-                    // Wait for HUD animation to finish before capturing.
                     tokio::time::sleep(std::time::Duration::from_millis(150)).await;
                     tokio::task::spawn_blocking(move || {
                         let shot = capture_primary_screen();
@@ -114,7 +112,6 @@ async fn stop_and_transcribe<R: Runtime>(
     shared_state: SharedState,
     recorder_state: Arc<Mutex<Recorder>>,
 ) {
-    // 停止录音
     let audio_data = {
         let mut recorder = recorder_state.lock().unwrap();
         match recorder.stop() {
@@ -127,7 +124,6 @@ async fn stop_and_transcribe<R: Runtime>(
         }
     };
 
-    // 切换到 Processing 状态
     {
         let mut state = shared_state.lock().unwrap();
         *state = AppState::Processing;
@@ -136,7 +132,6 @@ async fn stop_and_transcribe<R: Runtime>(
     let _ = app.emit("state-change", "processing");
     info!("状态 → Processing");
 
-    // 编码 WAV
     let wav_bytes = match encode_wav(
         &audio_data.samples,
         audio_data.sample_rate,
@@ -150,86 +145,33 @@ async fn stop_and_transcribe<R: Runtime>(
         }
     };
 
-    // 读取 provider 配置
-    let (provider, api_key, project_id, location, vertex_model) = {
+    // Read provider + config
+    let (provider, pcfg, polish_enabled) = {
         let config = app.state::<Arc<Mutex<AppConfig>>>();
         let cfg = config.lock().unwrap();
-        (
-            cfg.provider.clone(),
-            cfg.api_key.clone(),
-            cfg.gcp_project_id.clone(),
-            cfg.gcp_location.clone(),
-            cfg.vertex_model.clone(),
-        )
+        let p = cfg.provider.clone();
+        let mut pc = cfg.get_pcfg(&p);
+        // Groq: env var override
+        if p == "groq" {
+            if let Ok(key) = std::env::var("GROQ_API_KEY") {
+                if !key.is_empty() {
+                    pc["api_key"] = serde_json::Value::String(key);
+                }
+            }
+        }
+        (p, pc, cfg.polish_enabled)
     };
 
-    // 验证 provider 配置
-    match &provider {
-        Provider::Groq => {
-            let effective_key = std::env::var("GROQ_API_KEY")
-                .ok()
-                .filter(|k| !k.is_empty())
-                .unwrap_or(api_key.clone());
-            if effective_key.is_empty() {
-                warn!("未配置 Groq API Key");
-                let _ = app.emit("api-key-missing", ());
-                set_error(&app, &shared_state, "未配置 Groq API Key");
-                return;
-            }
-        }
-        Provider::VertexAi => {
-            if project_id.is_empty() {
-                warn!("Vertex AI 项目 ID 未配置");
-                let _ = app.emit("show-settings", ());
-                set_error(&app, &shared_state, "Vertex AI 未配置项目 ID");
-                return;
-            }
-        }
-    }
+    info!("使用 provider: {}", provider);
 
-    let effective_api_key = std::env::var("GROQ_API_KEY")
-        .ok()
-        .filter(|k| !k.is_empty())
-        .unwrap_or(api_key);
-
-    if provider == Provider::Groq {
-        info!(
-            "使用 Groq（Key 前8位: {}...）",
-            &effective_api_key[..effective_api_key.len().min(8)]
-        );
-    } else {
-        info!("使用 Vertex AI（项目: {}, 区域: {}, 模型: {}）", project_id, location, vertex_model);
-    }
-
-    // 转录
-    let raw_text = match &provider {
-        Provider::Groq => {
-            let client = GroqClient::new(effective_api_key.clone());
-            match client.transcribe(wav_bytes).await {
-                Ok(t) => t,
-                Err(e) => {
-                    error!("Groq 转录失败: {}", e);
-                    set_error(&app, &shared_state, &e.to_string());
-                    return;
-                }
-            }
-        }
-        Provider::VertexAi => {
-            match VertexClient::new(project_id.clone(), location.clone(), vertex_model.clone()).await {
-                Ok(client) => match client.transcribe(wav_bytes).await {
-                    Ok(t) => t,
-                    Err(e) => {
-                        error!("Vertex AI 转录失败: {}", e);
-                        set_error(&app, &shared_state, &e.to_string());
-                        return;
-                    }
-                },
-                Err(e) => {
-                    error!("Vertex AI 客户端初始化失败: {}", e);
-                    set_error(&app, &shared_state, &format!("Vertex AI 认证失败: {}", e));
-                    return;
-                }
-            }
+    // Transcribe
+    let raw_text = match transcribe_with_provider(&provider, &pcfg, wav_bytes).await {
+        Ok(t) => t,
+        Err(e) => {
+            error!("转录失败: {}", e);
+            let _ = app.emit("show-settings", ());
+            set_error(&app, &shared_state, &e.to_string());
+            return;
         }
     };
 
@@ -239,59 +181,36 @@ async fn stop_and_transcribe<R: Runtime>(
         return;
     }
 
-    // 润色（可选）
-    let text = {
-        let polish_enabled = {
-            let config = app.state::<Arc<Mutex<AppConfig>>>();
-            let enabled = config.lock().unwrap().polish_enabled;
-            enabled
+    // Polish
+    let text = if polish_enabled {
+        let screenshot = {
+            let screenshot_state = app.state::<ScreenshotState>();
+            let shot = screenshot_state.lock().unwrap().take();
+            shot
         };
-        if polish_enabled {
-            let screenshot = {
-                let screenshot_state = app.state::<ScreenshotState>();
-                let shot = screenshot_state.lock().unwrap().take();
-                shot
-            };
-            info!(
-                "润色开关已开启，调用 LLM 润色 (截图上下文: {})...",
-                if screenshot.is_some() { "有" } else { "无" }
-            );
-            let (polished, failed) = match &provider {
-                Provider::Groq => {
-                    polish::polish_text(&raw_text, &effective_api_key, screenshot.as_deref()).await
-                }
-                Provider::VertexAi => {
-                    vertex::polish_text_vertex(
-                        &raw_text,
-                        &project_id,
-                        &location,
-                        &vertex_model,
-                        screenshot.as_deref(),
-                    )
-                    .await
-                }
-            };
-            if failed {
-                let _ = app.emit("polish-failed", ());
-            }
-            polished
-        } else {
-            {
-                let screenshot_state = app.state::<ScreenshotState>();
-                screenshot_state.lock().unwrap().take();
-            }
-            raw_text
+        info!(
+            "润色开关已开启，调用 LLM 润色 (截图上下文: {})...",
+            if screenshot.is_some() { "有" } else { "无" }
+        );
+        let (polished, failed) =
+            polish_with_provider(&provider, &pcfg, &raw_text, screenshot.as_deref()).await;
+        if failed {
+            let _ = app.emit("polish-failed", ());
         }
+        polished
+    } else {
+        {
+            let screenshot_state = app.state::<ScreenshotState>();
+            screenshot_state.lock().unwrap().take();
+        }
+        raw_text
     };
 
-    // 更新托盘菜单显示最近转录
     crate::tray::set_tray_last_result(&app, &text);
 
-    // 注入文字
     let _ = app.emit("transcription-result", &text);
     if let Err(e) = inject_text(&text).await {
         error!("文字注入失败: {}", e);
-        // 文字已写入剪贴板，通知前端让用户手动粘贴
         if let Some(win) = app.get_webview_window("main") {
             let _ = win.show();
         }
@@ -302,6 +221,70 @@ async fn stop_and_transcribe<R: Runtime>(
     reset_to_idle(&app, &shared_state);
     info!("状态 → Idle");
 }
+
+// ---------------------------------------------------------------------------
+// Provider dispatch helpers — add a match arm here for each new provider.
+// ---------------------------------------------------------------------------
+
+async fn transcribe_with_provider(
+    provider: &str,
+    config: &serde_json::Value,
+    wav_bytes: Vec<u8>,
+) -> anyhow::Result<String> {
+    match provider {
+        "groq" => {
+            let api_key = config["api_key"].as_str().unwrap_or("");
+            if api_key.is_empty() {
+                anyhow::bail!("未配置 Groq API Key");
+            }
+            info!("Groq Key 前8位: {}...", &api_key[..api_key.len().min(8)]);
+            GroqClient::new(api_key.to_string())
+                .transcribe(wav_bytes)
+                .await
+        }
+        "vertex_ai" => {
+            let project_id = config["project_id"].as_str().unwrap_or("");
+            if project_id.is_empty() {
+                anyhow::bail!("Vertex AI 未配置项目 ID");
+            }
+            let location = config["location"].as_str().unwrap_or("us-central1");
+            let model = config["model"].as_str().unwrap_or("gemini-2.5-flash");
+            info!(
+                "Vertex AI: 项目={}, 区域={}, 模型={}",
+                project_id, location, model
+            );
+            let client =
+                VertexClient::new(project_id.into(), location.into(), model.into()).await?;
+            client.transcribe(wav_bytes).await
+        }
+        other => anyhow::bail!("不支持的 provider: {}", other),
+    }
+}
+
+async fn polish_with_provider(
+    provider: &str,
+    config: &serde_json::Value,
+    text: &str,
+    screenshot: Option<&str>,
+) -> (String, bool) {
+    match provider {
+        "groq" => {
+            let api_key = config["api_key"].as_str().unwrap_or("");
+            polish::polish_text(text, api_key, screenshot).await
+        }
+        "vertex_ai" => {
+            let project_id = config["project_id"].as_str().unwrap_or("");
+            let location = config["location"].as_str().unwrap_or("us-central1");
+            let model = config["model"].as_str().unwrap_or("gemini-2.5-flash");
+            vertex::polish_text_vertex(text, project_id, location, model, screenshot).await
+        }
+        _ => (text.to_string(), true),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
 
 fn set_error<R: Runtime>(app: &AppHandle<R>, shared_state: &SharedState, msg: &str) {
     {
@@ -334,8 +317,9 @@ fn schedule_error_recovery<R: Runtime>(app: AppHandle<R>, shared_state: SharedSt
     });
 }
 
-
-// --- Tauri IPC Commands ---
+// ===========================================================================
+// Tauri IPC Commands
+// ===========================================================================
 
 #[tauri::command]
 pub fn open_accessibility_prefs() {
@@ -348,39 +332,66 @@ pub fn get_accessibility_status() -> bool {
 }
 
 #[tauri::command]
-pub async fn save_api_key(
-    key: String,
+pub fn get_app_state(shared_state: tauri::State<'_, SharedState>) -> String {
+    shared_state.lock().unwrap().to_string()
+}
+
+// --- Generic provider commands -----------------------------------------------
+
+#[tauri::command]
+pub fn get_provider(config: tauri::State<'_, Arc<Mutex<AppConfig>>>) -> String {
+    config.lock().unwrap().provider.clone()
+}
+
+#[tauri::command]
+pub async fn save_provider(
+    provider: String,
     app: AppHandle,
     config: tauri::State<'_, Arc<Mutex<AppConfig>>>,
 ) -> Result<(), String> {
     let updated = {
         let mut cfg = config.lock().unwrap();
-        cfg.api_key = key.clone();
+        cfg.provider = provider;
         cfg.clone()
     };
     AppConfig::save(&app, &updated).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
-pub fn get_saved_api_key(
+pub fn get_provider_config(
+    provider: String,
     config: tauri::State<'_, Arc<Mutex<AppConfig>>>,
-) -> String {
-    config.lock().unwrap().api_key.clone()
+) -> serde_json::Value {
+    config.lock().unwrap().get_pcfg(&provider)
 }
 
 #[tauri::command]
-pub fn get_app_state(
-    shared_state: tauri::State<'_, SharedState>,
-) -> String {
-    shared_state.lock().unwrap().to_string()
+pub async fn save_provider_config(
+    provider: String,
+    config_values: serde_json::Value,
+    app: AppHandle,
+    config: tauri::State<'_, Arc<Mutex<AppConfig>>>,
+) -> Result<(), String> {
+    let updated = {
+        let mut cfg = config.lock().unwrap();
+        cfg.provider_configs.insert(provider, config_values);
+        cfg.clone()
+    };
+    AppConfig::save(&app, &updated).map_err(|e| e.to_string())
 }
 
-// --- Polish commands ---
+#[tauri::command]
+pub fn check_provider_status(provider: String) -> bool {
+    match provider.as_str() {
+        "vertex_ai" => vertex::check_adc_available(),
+        _ => true,
+    }
+}
+
+// --- Polish ------------------------------------------------------------------
 
 #[tauri::command]
-pub fn get_polish_enabled(
-    config: tauri::State<'_, Arc<Mutex<AppConfig>>>,
-) -> bool {
+pub fn get_polish_enabled(config: tauri::State<'_, Arc<Mutex<AppConfig>>>) -> bool {
     config.lock().unwrap().polish_enabled
 }
 
@@ -398,11 +409,18 @@ pub async fn save_polish_enabled(
     AppConfig::save(&app, &updated).map_err(|e| e.to_string())
 }
 
-// --- Audio device commands ---
+// --- Audio devices -----------------------------------------------------------
 
 #[tauri::command]
 pub fn list_audio_devices() -> Vec<String> {
     crate::audio::recorder::list_input_devices()
+}
+
+#[tauri::command]
+pub fn get_preferred_device(
+    config: tauri::State<'_, Arc<Mutex<AppConfig>>>,
+) -> Option<String> {
+    config.lock().unwrap().preferred_device.clone()
 }
 
 #[tauri::command]
@@ -419,12 +437,10 @@ pub async fn save_preferred_device(
     AppConfig::save(&app, &updated).map_err(|e| e.to_string())
 }
 
-// --- Shortcut commands ---
+// --- Shortcut ----------------------------------------------------------------
 
 #[tauri::command]
-pub fn get_shortcut(
-    config: tauri::State<'_, Arc<Mutex<AppConfig>>>,
-) -> String {
+pub fn get_shortcut(config: tauri::State<'_, Arc<Mutex<AppConfig>>>) -> String {
     config.lock().unwrap().shortcut.clone()
 }
 
@@ -440,25 +456,19 @@ pub async fn save_shortcut(
         cfg.clone()
     };
     AppConfig::save(&app, &updated).map_err(|e| e.to_string())?;
-    // Re-register shortcut
     crate::shortcut::reregister_shortcut(&app, &shortcut).map_err(|e| e.to_string())
 }
 
-// --- Autostart commands ---
+// --- Autostart ---------------------------------------------------------------
 
 #[tauri::command]
-pub fn get_autostart_enabled(
-    app: AppHandle,
-) -> bool {
+pub fn get_autostart_enabled(app: AppHandle) -> bool {
     use tauri_plugin_autostart::ManagerExt;
     app.autolaunch().is_enabled().unwrap_or(false)
 }
 
 #[tauri::command]
-pub async fn save_autostart_enabled(
-    enabled: bool,
-    app: AppHandle,
-) -> Result<(), String> {
+pub async fn save_autostart_enabled(enabled: bool, app: AppHandle) -> Result<(), String> {
     use tauri_plugin_autostart::ManagerExt;
     if enabled {
         app.autolaunch().enable().map_err(|e| e.to_string())
@@ -467,12 +477,10 @@ pub async fn save_autostart_enabled(
     }
 }
 
-// --- Screenshot context commands ---
+// --- Screenshot context ------------------------------------------------------
 
 #[tauri::command]
-pub fn get_screenshot_context_enabled(
-    config: tauri::State<'_, Arc<Mutex<AppConfig>>>,
-) -> bool {
+pub fn get_screenshot_context_enabled(config: tauri::State<'_, Arc<Mutex<AppConfig>>>) -> bool {
     config.lock().unwrap().screenshot_context_enabled
 }
 
@@ -490,12 +498,10 @@ pub async fn save_screenshot_context_enabled(
     AppConfig::save(&app, &updated).map_err(|e| e.to_string())
 }
 
-// --- Onboarding commands ---
+// --- Onboarding --------------------------------------------------------------
 
 #[tauri::command]
-pub fn get_onboarding_completed(
-    config: tauri::State<'_, Arc<Mutex<AppConfig>>>,
-) -> bool {
+pub fn get_onboarding_completed(config: tauri::State<'_, Arc<Mutex<AppConfig>>>) -> bool {
     config.lock().unwrap().onboarding_completed
 }
 
@@ -510,70 +516,4 @@ pub async fn save_onboarding_completed(
         cfg.clone()
     };
     AppConfig::save(&app, &updated).map_err(|e| e.to_string())
-}
-
-// --- Provider commands ---
-
-#[tauri::command]
-pub fn get_provider(
-    config: tauri::State<'_, Arc<Mutex<AppConfig>>>,
-) -> String {
-    let cfg = config.lock().unwrap();
-    serde_json::to_value(&cfg.provider)
-        .ok()
-        .and_then(|v| v.as_str().map(String::from))
-        .unwrap_or_else(|| "groq".to_string())
-}
-
-#[tauri::command]
-pub async fn save_provider(
-    provider: String,
-    app: AppHandle,
-    config: tauri::State<'_, Arc<Mutex<AppConfig>>>,
-) -> Result<(), String> {
-    let p: Provider =
-        serde_json::from_value(serde_json::Value::String(provider)).map_err(|e| e.to_string())?;
-    let updated = {
-        let mut cfg = config.lock().unwrap();
-        cfg.provider = p;
-        cfg.clone()
-    };
-    AppConfig::save(&app, &updated).map_err(|e| e.to_string())
-}
-
-// --- Vertex AI config commands ---
-
-#[tauri::command]
-pub fn get_vertex_config(
-    config: tauri::State<'_, Arc<Mutex<AppConfig>>>,
-) -> serde_json::Value {
-    let cfg = config.lock().unwrap();
-    serde_json::json!({
-        "project_id": cfg.gcp_project_id,
-        "location": cfg.gcp_location,
-        "model": cfg.vertex_model,
-    })
-}
-
-#[tauri::command]
-pub async fn save_vertex_config(
-    project_id: String,
-    location: String,
-    model: String,
-    app: AppHandle,
-    config: tauri::State<'_, Arc<Mutex<AppConfig>>>,
-) -> Result<(), String> {
-    let updated = {
-        let mut cfg = config.lock().unwrap();
-        cfg.gcp_project_id = project_id;
-        cfg.gcp_location = location;
-        cfg.vertex_model = model;
-        cfg.clone()
-    };
-    AppConfig::save(&app, &updated).map_err(|e| e.to_string())
-}
-
-#[tauri::command]
-pub fn check_vertex_auth() -> bool {
-    vertex::check_adc_available()
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -406,7 +406,14 @@ pub async fn save_polish_enabled(
         cfg.polish_enabled = enabled;
         cfg.clone()
     };
-    AppConfig::save(&app, &updated).map_err(|e| e.to_string())
+    AppConfig::save(&app, &updated).map_err(|e| e.to_string())?;
+    // Sync tray menu checkbox
+    if let Some(tray) = app.tray_by_id("main-tray") {
+        if let Ok(menu) = crate::tray::build_tray_menu(&app, enabled) {
+            let _ = tray.set_menu(Some(menu));
+        }
+    }
+    Ok(())
 }
 
 // --- Audio devices -----------------------------------------------------------

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -35,7 +35,7 @@ pub async fn toggle_recording<R: Runtime>(
             stop_and_transcribe(app, shared_state, recorder_state).await;
         }
         AppState::Processing => {
-            warn!("正在处理中，请稍候");
+            warn!("Still processing, please wait");
         }
         AppState::Error(_) => {
             let mut state = shared_state.lock().unwrap();
@@ -51,13 +51,13 @@ async fn start_recording<R: Runtime>(
     shared_state: SharedState,
     recorder_state: Arc<Mutex<Recorder>>,
 ) {
-    info!("开始录音...");
+    info!("Recording started...");
 
     let result = {
         match recorder_state.lock() {
             Ok(mut recorder) => recorder.start(app),
             Err(e) => {
-                error!("recorder 锁中毒: {}", e);
+                error!("Recorder lock poisoned: {}", e);
                 return;
             }
         }
@@ -70,7 +70,7 @@ async fn start_recording<R: Runtime>(
             drop(state);
             set_tray_icon(app, "recording");
             let _ = app.emit("state-change", "recording");
-            info!("状态 → Recording");
+            info!("State → Recording");
 
             let screenshot_context_enabled = {
                 let config = app.state::<Arc<Mutex<AppConfig>>>();
@@ -84,9 +84,9 @@ async fn start_recording<R: Runtime>(
                     tokio::task::spawn_blocking(move || {
                         let shot = capture_primary_screen();
                         if shot.is_some() {
-                            info!("截图已捕获，将用于润色上下文");
+                            info!("Screenshot captured for polish context");
                         } else {
-                            info!("截图捕获失败，将使用纯文字润色");
+                            info!("Screenshot capture failed, using text-only polish");
                         }
                         *ss.lock().unwrap() = shot;
                     });
@@ -96,7 +96,7 @@ async fn start_recording<R: Runtime>(
             }
         }
         Err(e) => {
-            error!("录音启动失败: {}", e);
+            error!("Recording start failed: {}", e);
             let mut state = shared_state.lock().unwrap();
             *state = AppState::Error(e.to_string());
             drop(state);
@@ -117,7 +117,7 @@ async fn stop_and_transcribe<R: Runtime>(
         match recorder.stop() {
             Ok(data) => data,
             Err(e) => {
-                error!("停止录音失败: {}", e);
+                error!("Recording stop failed: {}", e);
                 set_error(&app, &shared_state, &e.to_string());
                 return;
             }
@@ -130,7 +130,7 @@ async fn stop_and_transcribe<R: Runtime>(
     }
     set_tray_icon(&app, "processing");
     let _ = app.emit("state-change", "processing");
-    info!("状态 → Processing");
+    info!("State → Processing");
 
     let wav_bytes = match encode_wav(
         &audio_data.samples,
@@ -139,7 +139,7 @@ async fn stop_and_transcribe<R: Runtime>(
     ) {
         Ok(b) => b,
         Err(e) => {
-            error!("WAV 编码失败: {}", e);
+            error!("WAV encoding failed: {}", e);
             set_error(&app, &shared_state, &e.to_string());
             return;
         }
@@ -162,13 +162,13 @@ async fn stop_and_transcribe<R: Runtime>(
         (p, pc, cfg.polish_enabled)
     };
 
-    info!("使用 provider: {}", provider);
+    info!("Using provider: {}", provider);
 
     // Transcribe
     let raw_text = match transcribe_with_provider(&provider, &pcfg, wav_bytes).await {
         Ok(t) => t,
         Err(e) => {
-            error!("转录失败: {}", e);
+            error!("Transcription failed: {}", e);
             let _ = app.emit("show-settings", ());
             set_error(&app, &shared_state, &e.to_string());
             return;
@@ -176,7 +176,7 @@ async fn stop_and_transcribe<R: Runtime>(
     };
 
     if raw_text.is_empty() {
-        warn!("转录结果为空 — 可能静音、麦克风未授权或录音太短");
+        warn!("Transcription empty — possibly silence, mic unauthorized, or recording too short");
         reset_to_idle(&app, &shared_state);
         return;
     }
@@ -189,8 +189,8 @@ async fn stop_and_transcribe<R: Runtime>(
             shot
         };
         info!(
-            "润色开关已开启，调用 LLM 润色 (截图上下文: {})...",
-            if screenshot.is_some() { "有" } else { "无" }
+            "Polish enabled, calling LLM polish (screenshot context: {})...",
+            if screenshot.is_some() { "yes" } else { "no" }
         );
         let (polished, failed) =
             polish_with_provider(&provider, &pcfg, &raw_text, screenshot.as_deref()).await;
@@ -210,7 +210,7 @@ async fn stop_and_transcribe<R: Runtime>(
 
     let _ = app.emit("transcription-result", &text);
     if let Err(e) = inject_text(&text).await {
-        error!("文字注入失败: {}", e);
+        error!("Text injection failed: {}", e);
         if let Some(win) = app.get_webview_window("main") {
             let _ = win.show();
         }
@@ -219,7 +219,7 @@ async fn stop_and_transcribe<R: Runtime>(
     }
 
     reset_to_idle(&app, &shared_state);
-    info!("状态 → Idle");
+    info!("State → Idle");
 }
 
 // ---------------------------------------------------------------------------
@@ -235,9 +235,9 @@ async fn transcribe_with_provider(
         "groq" => {
             let api_key = config["api_key"].as_str().unwrap_or("");
             if api_key.is_empty() {
-                anyhow::bail!("未配置 Groq API Key");
+                anyhow::bail!("Groq API Key not configured");
             }
-            info!("Groq Key 前8位: {}...", &api_key[..api_key.len().min(8)]);
+            info!("Groq Key prefix: {}...", &api_key[..api_key.len().min(8)]);
             GroqClient::new(api_key.to_string())
                 .transcribe(wav_bytes)
                 .await
@@ -245,19 +245,19 @@ async fn transcribe_with_provider(
         "vertex_ai" => {
             let project_id = config["project_id"].as_str().unwrap_or("");
             if project_id.is_empty() {
-                anyhow::bail!("Vertex AI 未配置项目 ID");
+                anyhow::bail!("Vertex AI project ID not configured");
             }
             let location = config["location"].as_str().unwrap_or("us-central1");
             let model = config["model"].as_str().unwrap_or("gemini-2.5-flash");
             info!(
-                "Vertex AI: 项目={}, 区域={}, 模型={}",
+                "Vertex AI: project={}, region={}, model={}",
                 project_id, location, model
             );
             let client =
                 VertexClient::new(project_id.into(), location.into(), model.into()).await?;
             client.transcribe(wav_bytes).await
         }
-        other => anyhow::bail!("不支持的 provider: {}", other),
+        other => anyhow::bail!("Unsupported provider: {}", other),
     }
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,10 +1,10 @@
 use crate::{
     audio::{encode_wav, Recorder},
-    config::AppConfig,
+    config::{AppConfig, Provider},
     input::inject_text,
     screenshot::capture_primary_screen,
     state::{AppState, ScreenshotState, SharedState},
-    transcription::{polish, GroqClient},
+    transcription::{polish, vertex, GroqClient, VertexClient},
     tray::set_tray_icon,
 };
 use std::sync::{Arc, Mutex};
@@ -150,28 +150,86 @@ async fn stop_and_transcribe<R: Runtime>(
         }
     };
 
-    // 读取 API Key
-    let api_key = match get_api_key(&app) {
-        Some(k) => {
-            info!("API Key 已加载（前8位: {}...）", &k[..k.len().min(8)]);
-            k
-        }
-        None => {
-            warn!("未配置 API Key — 请通过托盘菜单「配置 API Key」填入");
-            let _ = app.emit("api-key-missing", ());
-            set_error(&app, &shared_state, "未配置 Groq API Key");
-            return;
-        }
+    // 读取 provider 配置
+    let (provider, api_key, project_id, location, vertex_model) = {
+        let config = app.state::<Arc<Mutex<AppConfig>>>();
+        let cfg = config.lock().unwrap();
+        (
+            cfg.provider.clone(),
+            cfg.api_key.clone(),
+            cfg.gcp_project_id.clone(),
+            cfg.gcp_location.clone(),
+            cfg.vertex_model.clone(),
+        )
     };
 
-    // 调用 Groq API
-    let client = GroqClient::new(api_key.clone());
-    let raw_text = match client.transcribe(wav_bytes).await {
-        Ok(t) => t,
-        Err(e) => {
-            error!("转录失败: {}", e);
-            set_error(&app, &shared_state, &e.to_string());
-            return;
+    // 验证 provider 配置
+    match &provider {
+        Provider::Groq => {
+            let effective_key = std::env::var("GROQ_API_KEY")
+                .ok()
+                .filter(|k| !k.is_empty())
+                .unwrap_or(api_key.clone());
+            if effective_key.is_empty() {
+                warn!("未配置 Groq API Key");
+                let _ = app.emit("api-key-missing", ());
+                set_error(&app, &shared_state, "未配置 Groq API Key");
+                return;
+            }
+        }
+        Provider::VertexAi => {
+            if project_id.is_empty() {
+                warn!("Vertex AI 项目 ID 未配置");
+                let _ = app.emit("show-settings", ());
+                set_error(&app, &shared_state, "Vertex AI 未配置项目 ID");
+                return;
+            }
+        }
+    }
+
+    let effective_api_key = std::env::var("GROQ_API_KEY")
+        .ok()
+        .filter(|k| !k.is_empty())
+        .unwrap_or(api_key);
+
+    if provider == Provider::Groq {
+        info!(
+            "使用 Groq（Key 前8位: {}...）",
+            &effective_api_key[..effective_api_key.len().min(8)]
+        );
+    } else {
+        info!("使用 Vertex AI（项目: {}, 区域: {}, 模型: {}）", project_id, location, vertex_model);
+    }
+
+    // 转录
+    let raw_text = match &provider {
+        Provider::Groq => {
+            let client = GroqClient::new(effective_api_key.clone());
+            match client.transcribe(wav_bytes).await {
+                Ok(t) => t,
+                Err(e) => {
+                    error!("Groq 转录失败: {}", e);
+                    set_error(&app, &shared_state, &e.to_string());
+                    return;
+                }
+            }
+        }
+        Provider::VertexAi => {
+            match VertexClient::new(project_id.clone(), location.clone(), vertex_model.clone()).await {
+                Ok(client) => match client.transcribe(wav_bytes).await {
+                    Ok(t) => t,
+                    Err(e) => {
+                        error!("Vertex AI 转录失败: {}", e);
+                        set_error(&app, &shared_state, &e.to_string());
+                        return;
+                    }
+                },
+                Err(e) => {
+                    error!("Vertex AI 客户端初始化失败: {}", e);
+                    set_error(&app, &shared_state, &format!("Vertex AI 认证失败: {}", e));
+                    return;
+                }
+            }
         }
     };
 
@@ -189,24 +247,39 @@ async fn stop_and_transcribe<R: Runtime>(
             enabled
         };
         if polish_enabled {
-            // Take the screenshot out of state (clears it for the next recording).
             let screenshot = {
                 let screenshot_state = app.state::<ScreenshotState>();
                 let shot = screenshot_state.lock().unwrap().take();
                 shot
             };
-            info!("润色开关已开启，调用 LLM 润色 (截图上下文: {})...",
-                  if screenshot.is_some() { "有" } else { "无" });
-            let (polished, failed) =
-                polish::polish_text(&raw_text, &api_key, screenshot.as_deref()).await;
+            info!(
+                "润色开关已开启，调用 LLM 润色 (截图上下文: {})...",
+                if screenshot.is_some() { "有" } else { "无" }
+            );
+            let (polished, failed) = match &provider {
+                Provider::Groq => {
+                    polish::polish_text(&raw_text, &effective_api_key, screenshot.as_deref()).await
+                }
+                Provider::VertexAi => {
+                    vertex::polish_text_vertex(
+                        &raw_text,
+                        &project_id,
+                        &location,
+                        &vertex_model,
+                        screenshot.as_deref(),
+                    )
+                    .await
+                }
+            };
             if failed {
                 let _ = app.emit("polish-failed", ());
             }
             polished
         } else {
-            // Clear screenshot state even if polish is disabled.
-            let screenshot_state = app.state::<ScreenshotState>();
-            screenshot_state.lock().unwrap().take();
+            {
+                let screenshot_state = app.state::<ScreenshotState>();
+                screenshot_state.lock().unwrap().take();
+            }
             raw_text
         }
     };
@@ -261,22 +334,6 @@ fn schedule_error_recovery<R: Runtime>(app: AppHandle<R>, shared_state: SharedSt
     });
 }
 
-fn get_api_key<R: Runtime>(app: &AppHandle<R>) -> Option<String> {
-    // 优先环境变量
-    if let Ok(key) = std::env::var("GROQ_API_KEY") {
-        if !key.is_empty() {
-            return Some(key);
-        }
-    }
-    // 其次读持久化配置
-    let config = app.state::<Arc<Mutex<AppConfig>>>();
-    let cfg = config.lock().unwrap();
-    if cfg.api_key.is_empty() {
-        None
-    } else {
-        Some(cfg.api_key.clone())
-    }
-}
 
 // --- Tauri IPC Commands ---
 
@@ -453,4 +510,70 @@ pub async fn save_onboarding_completed(
         cfg.clone()
     };
     AppConfig::save(&app, &updated).map_err(|e| e.to_string())
+}
+
+// --- Provider commands ---
+
+#[tauri::command]
+pub fn get_provider(
+    config: tauri::State<'_, Arc<Mutex<AppConfig>>>,
+) -> String {
+    let cfg = config.lock().unwrap();
+    serde_json::to_value(&cfg.provider)
+        .ok()
+        .and_then(|v| v.as_str().map(String::from))
+        .unwrap_or_else(|| "groq".to_string())
+}
+
+#[tauri::command]
+pub async fn save_provider(
+    provider: String,
+    app: AppHandle,
+    config: tauri::State<'_, Arc<Mutex<AppConfig>>>,
+) -> Result<(), String> {
+    let p: Provider =
+        serde_json::from_value(serde_json::Value::String(provider)).map_err(|e| e.to_string())?;
+    let updated = {
+        let mut cfg = config.lock().unwrap();
+        cfg.provider = p;
+        cfg.clone()
+    };
+    AppConfig::save(&app, &updated).map_err(|e| e.to_string())
+}
+
+// --- Vertex AI config commands ---
+
+#[tauri::command]
+pub fn get_vertex_config(
+    config: tauri::State<'_, Arc<Mutex<AppConfig>>>,
+) -> serde_json::Value {
+    let cfg = config.lock().unwrap();
+    serde_json::json!({
+        "project_id": cfg.gcp_project_id,
+        "location": cfg.gcp_location,
+        "model": cfg.vertex_model,
+    })
+}
+
+#[tauri::command]
+pub async fn save_vertex_config(
+    project_id: String,
+    location: String,
+    model: String,
+    app: AppHandle,
+    config: tauri::State<'_, Arc<Mutex<AppConfig>>>,
+) -> Result<(), String> {
+    let updated = {
+        let mut cfg = config.lock().unwrap();
+        cfg.gcp_project_id = project_id;
+        cfg.gcp_location = location;
+        cfg.vertex_model = model;
+        cfg.clone()
+    };
+    AppConfig::save(&app, &updated).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn check_vertex_auth() -> bool {
+    vertex::check_adc_available()
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -524,3 +524,60 @@ pub async fn save_onboarding_completed(
     };
     AppConfig::save(&app, &updated).map_err(|e| e.to_string())
 }
+
+/// Toggle NSWindow.isOpaque at runtime so WebKit uses the high-quality opaque
+/// text rendering path when showing panels, and transparent mode for the HUD.
+#[tauri::command]
+pub fn set_native_opaque(opaque: bool) {
+    #[cfg(target_os = "macos")]
+    {
+        use objc::{class, msg_send, sel, sel_impl};
+        unsafe {
+            let app: *mut objc::runtime::Object =
+                msg_send![class!(NSApplication), sharedApplication];
+            let windows: *mut objc::runtime::Object = msg_send![app, windows];
+            let count: usize = msg_send![windows, count];
+            for i in 0..count {
+                let win: *mut objc::runtime::Object =
+                    msg_send![windows, objectAtIndex: i];
+                let is_visible: bool = msg_send![win, isVisible];
+                if !is_visible {
+                    continue;
+                }
+                let _: () = msg_send![win, setOpaque: opaque];
+                let bg: *mut objc::runtime::Object = if opaque {
+                    msg_send![
+                        class!(NSColor),
+                        colorWithRed: 0.118f64
+                        green: 0.118f64
+                        blue: 0.125f64
+                        alpha: 1.0f64
+                    ]
+                } else {
+                    msg_send![class!(NSColor), clearColor]
+                };
+                let _: () = msg_send![win, setBackgroundColor: bg];
+
+                // Round the window frame view (superview of contentView)
+                // so the opaque background is clipped to rounded corners
+                let content: *mut objc::runtime::Object = msg_send![win, contentView];
+                let frame_view: *mut objc::runtime::Object = msg_send![content, superview];
+                if !frame_view.is_null() {
+                    let _: () = msg_send![frame_view, setWantsLayer: true];
+                    let layer: *mut objc::runtime::Object = msg_send![frame_view, layer];
+                    if !layer.is_null() {
+                        if opaque {
+                            let _: () = msg_send![layer, setCornerRadius: 16.0f64];
+                            let _: () = msg_send![layer, setMasksToBounds: true];
+                        } else {
+                            let _: () = msg_send![layer, setCornerRadius: 0.0f64];
+                            let _: () = msg_send![layer, setMasksToBounds: false];
+                        }
+                    }
+                }
+
+                let _: () = msg_send![win, invalidateShadow];
+            }
+        }
+    }
+}

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -73,7 +73,7 @@ impl AppConfig {
         if let Ok(data) = std::fs::read_to_string(&path) {
             if let Ok(mut cfg) = serde_json::from_str::<AppConfig>(&data) {
                 cfg.migrate_legacy();
-                info!("加载配置: {:?}", path);
+                info!("Config loaded: {:?}", path);
                 return cfg;
             }
         }
@@ -87,7 +87,7 @@ impl AppConfig {
         }
         let data = serde_json::to_string_pretty(config)?;
         std::fs::write(&path, data)?;
-        info!("保存配置: {:?}", path);
+        info!("Config saved: {:?}", path);
         Ok(())
     }
 

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,33 +1,32 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use tauri::{AppHandle, Manager, Runtime};
 use tracing::info;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub enum Provider {
-    Groq,
-    VertexAi,
+fn default_provider() -> String {
+    "groq".to_string()
 }
 
-impl Default for Provider {
-    fn default() -> Self {
-        Provider::Groq
-    }
+fn default_polish_enabled() -> bool {
+    true
+}
+
+fn default_shortcut() -> String {
+    #[cfg(target_os = "windows")]
+    return "Ctrl+Shift+Space".to_string();
+    #[cfg(not(target_os = "windows"))]
+    return "Meta+Shift+Space".to_string();
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppConfig {
-    pub api_key: String,
+    #[serde(default = "default_provider")]
+    pub provider: String,
     #[serde(default)]
-    pub provider: Provider,
-    #[serde(default)]
-    pub gcp_project_id: String,
-    #[serde(default = "default_gcp_location")]
-    pub gcp_location: String,
-    #[serde(default = "default_vertex_model")]
-    pub vertex_model: String,
+    pub provider_configs: HashMap<String, serde_json::Value>,
+
     #[serde(default = "default_polish_enabled")]
     pub polish_enabled: bool,
     #[serde(default)]
@@ -38,40 +37,32 @@ pub struct AppConfig {
     pub onboarding_completed: bool,
     #[serde(default)]
     pub screenshot_context_enabled: bool,
-}
 
-fn default_polish_enabled() -> bool {
-    true
-}
-
-fn default_gcp_location() -> String {
-    "us-central1".to_string()
-}
-
-fn default_vertex_model() -> String {
-    "gemini-2.5-flash".to_string()
-}
-
-fn default_shortcut() -> String {
-    #[cfg(target_os = "windows")]
-    return "Ctrl+Shift+Space".to_string();
-    #[cfg(not(target_os = "windows"))]
-    return "Meta+Shift+Space".to_string();
+    // Legacy fields — read for migration, never written back.
+    #[serde(default, skip_serializing)]
+    api_key: String,
+    #[serde(default, skip_serializing)]
+    gcp_project_id: String,
+    #[serde(default, skip_serializing)]
+    gcp_location: String,
+    #[serde(default, skip_serializing)]
+    vertex_model: String,
 }
 
 impl Default for AppConfig {
     fn default() -> Self {
         AppConfig {
-            api_key: String::new(),
-            provider: Provider::Groq,
-            gcp_project_id: String::new(),
-            gcp_location: default_gcp_location(),
-            vertex_model: default_vertex_model(),
+            provider: default_provider(),
+            provider_configs: HashMap::new(),
             polish_enabled: true,
             preferred_device: None,
             shortcut: default_shortcut(),
             onboarding_completed: false,
             screenshot_context_enabled: false,
+            api_key: String::new(),
+            gcp_project_id: String::new(),
+            gcp_location: String::new(),
+            vertex_model: String::new(),
         }
     }
 }
@@ -80,7 +71,8 @@ impl AppConfig {
     pub fn load<R: Runtime>(app: &AppHandle<R>) -> Self {
         let path = config_path(app);
         if let Ok(data) = std::fs::read_to_string(&path) {
-            if let Ok(cfg) = serde_json::from_str::<AppConfig>(&data) {
+            if let Ok(mut cfg) = serde_json::from_str::<AppConfig>(&data) {
+                cfg.migrate_legacy();
                 info!("加载配置: {:?}", path);
                 return cfg;
             }
@@ -97,6 +89,52 @@ impl AppConfig {
         std::fs::write(&path, data)?;
         info!("保存配置: {:?}", path);
         Ok(())
+    }
+
+    /// Migrate v0.2–v0.3.5-alpha legacy top-level fields into provider_configs.
+    fn migrate_legacy(&mut self) {
+        if !self.api_key.is_empty() && !self.provider_configs.contains_key("groq") {
+            self.provider_configs.insert(
+                "groq".into(),
+                serde_json::json!({ "api_key": self.api_key }),
+            );
+        }
+        self.api_key.clear();
+
+        if !self.gcp_project_id.is_empty() && !self.provider_configs.contains_key("vertex_ai") {
+            let loc = if self.gcp_location.is_empty() {
+                "us-central1"
+            } else {
+                &self.gcp_location
+            };
+            let model = if self.vertex_model.is_empty() {
+                "gemini-2.5-flash"
+            } else {
+                &self.vertex_model
+            };
+            self.provider_configs.insert(
+                "vertex_ai".into(),
+                serde_json::json!({
+                    "project_id": self.gcp_project_id,
+                    "location": loc,
+                    "model": model,
+                }),
+            );
+        }
+        self.gcp_project_id.clear();
+        self.gcp_location.clear();
+        self.vertex_model.clear();
+
+        // Migrate enum-serialised provider value (e.g. `"groq"` / `"vertex_ai"`)
+        // Already strings, so nothing to do — serde handles it.
+    }
+
+    /// Helper: get a provider's config, returning an empty object if absent.
+    pub fn get_pcfg(&self, provider: &str) -> serde_json::Value {
+        self.provider_configs
+            .get(provider)
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({}))
     }
 }
 

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -4,9 +4,30 @@ use std::path::PathBuf;
 use tauri::{AppHandle, Manager, Runtime};
 use tracing::info;
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum Provider {
+    Groq,
+    VertexAi,
+}
+
+impl Default for Provider {
+    fn default() -> Self {
+        Provider::Groq
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppConfig {
     pub api_key: String,
+    #[serde(default)]
+    pub provider: Provider,
+    #[serde(default)]
+    pub gcp_project_id: String,
+    #[serde(default = "default_gcp_location")]
+    pub gcp_location: String,
+    #[serde(default = "default_vertex_model")]
+    pub vertex_model: String,
     #[serde(default = "default_polish_enabled")]
     pub polish_enabled: bool,
     #[serde(default)]
@@ -23,6 +44,14 @@ fn default_polish_enabled() -> bool {
     true
 }
 
+fn default_gcp_location() -> String {
+    "us-central1".to_string()
+}
+
+fn default_vertex_model() -> String {
+    "gemini-2.5-flash".to_string()
+}
+
 fn default_shortcut() -> String {
     #[cfg(target_os = "windows")]
     return "Ctrl+Shift+Space".to_string();
@@ -34,6 +63,10 @@ impl Default for AppConfig {
     fn default() -> Self {
         AppConfig {
             api_key: String::new(),
+            provider: Provider::Groq,
+            gcp_project_id: String::new(),
+            gcp_location: default_gcp_location(),
+            vertex_model: default_vertex_model(),
             polish_enabled: true,
             preferred_device: None,
             shortcut: default_shortcut(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,8 @@ mod audio;
 mod commands;
 mod config;
 mod input;
+#[cfg(target_os = "macos")]
+mod macos_shortcut;
 mod screenshot;
 mod shortcut;
 mod state;
@@ -19,13 +21,13 @@ use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
 use tracing::{info, warn};
 
 pub fn run() {
-    // 依次尝试当前目录、父目录（src-tauri 的上级），确保 dev 模式能找到 .env
+    // Try current dir, then parent dir, to find .env in dev mode
     if dotenvy::dotenv().is_err() {
         let _ = dotenvy::from_path("../.env");
     }
 
-    // 同时写 stderr 和 ~/Library/Logs/com.audioinput.app/app.log
-    // 打包后 stderr 不可见，日志文件是唯一的调试手段
+    // Write to both stderr and a log file
+    // In packaged builds stderr is invisible; the log file is the only debug channel
     let log_path = {
         let mut p = dirs::cache_dir()
             .unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
@@ -54,9 +56,9 @@ pub fn run() {
     } else {
         tracing_subscriber::fmt().with_env_filter(filter).init();
     }
-    info!("日志文件: {:?}", log_path);
+    info!("Log file: {:?}", log_path);
 
-    info!("Audio Input 启动");
+    info!("Audio Input starting");
 
     tauri::Builder::default()
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
@@ -68,7 +70,7 @@ pub fn run() {
         .setup(|app| {
             let handle = app.handle().clone();
 
-            // macOS: 设置为 Accessory 激活策略（纯托盘应用，窗口不抢夺其他 app 的焦点）
+            // macOS: Set activation policy to Accessory (tray-only app, windows don't steal focus)
             #[cfg(target_os = "macos")]
             {
                 use objc::{class, msg_send, sel, sel_impl};
@@ -80,72 +82,112 @@ pub fn run() {
                 }
             }
 
-            // 初始化持久化配置
+            // Load persisted config
             let config = AppConfig::load(&handle);
             let shortcut_str = config.shortcut.clone();
             app.manage(Arc::new(Mutex::new(config)));
 
-            // 初始化应用状态
+            // Init shared state
             let shared_state = new_shared_state();
             app.manage(shared_state.clone());
 
-            // 初始化截图上下文状态
+            // Init screenshot context state
             app.manage(new_screenshot_state());
 
-            // 初始化录音器
+            // Init recorder
             let recorder = Arc::new(Mutex::new(Recorder::new()));
             app.manage(RecorderState(Arc::clone(&recorder)));
 
-            // 设置系统托盘
+            // Setup system tray
             tray::setup_tray(&handle)?;
 
-            // 诊断：显示当前 binary 路径和 AX 权限状态
-            info!("Binary 路径: {:?}", std::env::current_exe().unwrap_or_default());
+            // Diagnostics: binary path and accessibility status
+            info!("Binary path: {:?}", std::env::current_exe().unwrap_or_default());
             if input::injector::check_accessibility_permission() {
-                info!("Accessibility 权限: 已授权 ✓");
+                info!("Accessibility permission: granted ✓");
             } else {
-                warn!("Accessibility 权限: 未授权 (AXIsProcessTrusted=false)");
+                warn!("Accessibility permission: denied (AXIsProcessTrusted=false)");
             }
 
-            // 注册全局快捷键（从配置读取，默认 Cmd+Shift+Space）
+            // Register global shortcut (from config, default Meta+Shift+Space).
+            //
+            // On macOS we use a CGEventTap at the HID level so our shortcut fires
+            // even when another app (e.g. 1Password) has registered the same combo
+            // via a session-level event tap.  Falls back to Tauri's Carbon-based
+            // global-shortcut plugin if CGEventTap is unavailable.
             {
                 use tauri::Emitter as _;
 
-                // Unregister any stale shortcuts first to maximise chance of success
-                let _ = handle.global_shortcut().unregister_all();
-
-                let handle2 = handle.clone();
-                let shared_state2 = shared_state.clone();
-                let recorder2 = Arc::clone(&recorder);
-
-                let sc = shortcut::parse_shortcut(&shortcut_str)
-                    .unwrap_or_else(|_| {
-                        use tauri_plugin_global_shortcut::{Code, Modifiers, Shortcut};
-                        Shortcut::new(Some(Modifiers::META | Modifiers::SHIFT), Code::Space)
-                    });
-
-                match handle.global_shortcut().on_shortcut(
-                    sc,
-                    move |_app, _shortcut, event| {
-                        if event.state() == ShortcutState::Pressed {
-                            let app = handle2.clone();
-                            let state = shared_state2.clone();
-                            let rec = Arc::clone(&recorder2);
-                            tauri::async_runtime::spawn(async move {
-                                commands::toggle_recording(app, state, rec).await;
-                            });
+                #[cfg(target_os = "macos")]
+                let hid_ok = {
+                    let h = handle.clone();
+                    let ss = shared_state.clone();
+                    let rec = Arc::clone(&recorder);
+                    match macos_shortcut::install(&shortcut_str, move || {
+                        let app = h.clone();
+                        let state = ss.clone();
+                        let r = Arc::clone(&rec);
+                        tauri::async_runtime::spawn(async move {
+                            commands::toggle_recording(app, state, r).await;
+                        });
+                    }) {
+                        Ok(sh) => {
+                            app.manage(sh);
+                            info!(
+                                "Global shortcut {} registered via CGEventTap (HID-level, overrides other apps)",
+                                shortcut_str
+                            );
+                            true
                         }
-                    },
-                ) {
-                    Ok(_) => info!("全局快捷键 {} 注册成功", shortcut_str),
-                    Err(e) => {
-                        warn!("全局快捷键 {} 注册失败 ({}), 请在设置中更改快捷键", shortcut_str, e);
-                        let _ = handle.emit("shortcut-conflict", shortcut_str.clone());
+                        Err(e) => {
+                            warn!(
+                                "CGEventTap shortcut failed: {} — falling back to Carbon hotkey",
+                                e
+                            );
+                            false
+                        }
+                    }
+                };
+
+                #[cfg(not(target_os = "macos"))]
+                let hid_ok = false;
+
+                if !hid_ok {
+                    let _ = handle.global_shortcut().unregister_all();
+
+                    let handle2 = handle.clone();
+                    let shared_state2 = shared_state.clone();
+                    let recorder2 = Arc::clone(&recorder);
+
+                    let sc = shortcut::parse_shortcut(&shortcut_str)
+                        .unwrap_or_else(|_| {
+                            use tauri_plugin_global_shortcut::{Code, Modifiers, Shortcut};
+                            Shortcut::new(Some(Modifiers::META | Modifiers::SHIFT), Code::Space)
+                        });
+
+                    match handle.global_shortcut().on_shortcut(
+                        sc,
+                        move |_app, _shortcut, event| {
+                            if event.state() == ShortcutState::Pressed {
+                                let app = handle2.clone();
+                                let state = shared_state2.clone();
+                                let rec = Arc::clone(&recorder2);
+                                tauri::async_runtime::spawn(async move {
+                                    commands::toggle_recording(app, state, rec).await;
+                                });
+                            }
+                        },
+                    ) {
+                        Ok(_) => info!("Global shortcut {} registered (Carbon hotkey)", shortcut_str),
+                        Err(e) => {
+                            warn!("Global shortcut {} registration failed ({}), change it in Settings", shortcut_str, e);
+                            let _ = handle.emit("shortcut-conflict", shortcut_str.clone());
+                        }
                     }
                 }
             }
 
-            // 监听来自托盘点击的 toggle 事件
+            // Listen for toggle event from tray click
             {
                 let handle3 = handle.clone();
                 let shared_state3 = shared_state.clone();
@@ -187,5 +229,5 @@ pub fn run() {
             commands::save_screenshot_context_enabled,
         ])
         .run(tauri::generate_context!())
-        .expect("启动 Tauri 应用失败");
+        .expect("Failed to start Tauri application");
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -227,6 +227,7 @@ pub fn run() {
             commands::save_onboarding_completed,
             commands::get_screenshot_context_enabled,
             commands::save_screenshot_context_enabled,
+            commands::set_native_opaque,
         ])
         .run(tauri::generate_context!())
         .expect("Failed to start Tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -173,6 +173,11 @@ pub fn run() {
             commands::save_onboarding_completed,
             commands::get_screenshot_context_enabled,
             commands::save_screenshot_context_enabled,
+            commands::get_provider,
+            commands::save_provider,
+            commands::get_vertex_config,
+            commands::save_vertex_config,
+            commands::check_vertex_auth,
         ])
         .run(tauri::generate_context!())
         .expect("启动 Tauri 应用失败");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -109,6 +109,11 @@ pub fn run() {
 
             // 注册全局快捷键（从配置读取，默认 Cmd+Shift+Space）
             {
+                use tauri::Emitter as _;
+
+                // Unregister any stale shortcuts first to maximise chance of success
+                let _ = handle.global_shortcut().unregister_all();
+
                 let handle2 = handle.clone();
                 let shared_state2 = shared_state.clone();
                 let recorder2 = Arc::clone(&recorder);
@@ -133,7 +138,10 @@ pub fn run() {
                     },
                 ) {
                     Ok(_) => info!("全局快捷键 {} 注册成功", shortcut_str),
-                    Err(e) => warn!("全局快捷键 {} 注册失败 ({}), 请在设置中更改快捷键", shortcut_str, e),
+                    Err(e) => {
+                        warn!("全局快捷键 {} 注册失败 ({}), 请在设置中更改快捷键", shortcut_str, e);
+                        let _ = handle.emit("shortcut-conflict", shortcut_str.clone());
+                    }
                 }
             }
 
@@ -156,14 +164,18 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
-            commands::save_api_key,
-            commands::get_saved_api_key,
             commands::get_app_state,
             commands::open_accessibility_prefs,
             commands::get_accessibility_status,
+            commands::get_provider,
+            commands::save_provider,
+            commands::get_provider_config,
+            commands::save_provider_config,
+            commands::check_provider_status,
             commands::get_polish_enabled,
             commands::save_polish_enabled,
             commands::list_audio_devices,
+            commands::get_preferred_device,
             commands::save_preferred_device,
             commands::get_shortcut,
             commands::save_shortcut,
@@ -173,11 +185,6 @@ pub fn run() {
             commands::save_onboarding_completed,
             commands::get_screenshot_context_enabled,
             commands::save_screenshot_context_enabled,
-            commands::get_provider,
-            commands::save_provider,
-            commands::get_vertex_config,
-            commands::save_vertex_config,
-            commands::check_vertex_auth,
         ])
         .run(tauri::generate_context!())
         .expect("启动 Tauri 应用失败");

--- a/src-tauri/src/macos_shortcut.rs
+++ b/src-tauri/src/macos_shortcut.rs
@@ -1,0 +1,264 @@
+//! macOS-specific global shortcut via CGEventTap at the HID level.
+//!
+//! The Tauri global-shortcut plugin uses Carbon `RegisterEventHotKey`, which sits
+//! *after* CGEventTap in the macOS event chain. Apps like 1Password that register
+//! a CGEventTap at the session level consume matching key events before Carbon
+//! hotkeys ever fire.
+//!
+//! By installing our own tap at `kCGHIDEventTap` (the earliest interception point),
+//! we see the event first and can consume it — preventing other apps from stealing
+//! the shortcut.
+//!
+//! Requires Accessibility permission (the app already requests this).
+
+use anyhow::{bail, Result};
+use std::ffi::c_void;
+use std::sync::{Arc, Mutex};
+use tracing::info;
+
+
+// ── CoreGraphics FFI ────────────────────────────────────────────────────────
+
+#[link(name = "CoreGraphics", kind = "framework")]
+extern "C" {
+    fn CGEventTapCreate(
+        tap: u32,
+        place: u32,
+        options: u32,
+        events_of_interest: u64,
+        callback: unsafe extern "C" fn(
+            proxy: *mut c_void,
+            event_type: u32,
+            event: *mut c_void,
+            user_info: *mut c_void,
+        ) -> *mut c_void,
+        user_info: *mut c_void,
+    ) -> *mut c_void;
+    fn CGEventTapEnable(tap: *mut c_void, enable: bool);
+    fn CGEventGetIntegerValueField(event: *mut c_void, field: u32) -> i64;
+    fn CGEventGetFlags(event: *mut c_void) -> u64;
+}
+
+#[link(name = "CoreFoundation", kind = "framework")]
+extern "C" {
+    fn CFMachPortCreateRunLoopSource(
+        allocator: *const c_void,
+        port: *mut c_void,
+        order: i64,
+    ) -> *mut c_void;
+    fn CFRunLoopGetCurrent() -> *mut c_void;
+    fn CFRunLoopAddSource(rl: *mut c_void, source: *mut c_void, mode: *const c_void);
+    fn CFRunLoopRun();
+    static kCFRunLoopCommonModes: *const c_void;
+}
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+const KCG_HID_EVENT_TAP: u32 = 0;
+const KCG_HEAD_INSERT_EVENT_TAP: u32 = 0;
+const KCG_EVENT_TAP_OPTION_DEFAULT: u32 = 0;
+
+const KCG_EVENT_KEY_DOWN: u32 = 10;
+const KCG_EVENT_KEY_UP: u32 = 11;
+const KCG_EVENT_TAP_DISABLED_BY_TIMEOUT: u32 = 0xFFFF_FFFE;
+
+const KCG_KEYBOARD_EVENT_KEYCODE: u32 = 9;
+
+/// Mask covering only the four modifier keys we care about.
+const MODIFIER_MASK: u64 = (1 << 20) | (1 << 19) | (1 << 18) | (1 << 17);
+// Cmd=20, Alt=19, Ctrl=18, Shift=17
+
+// ── Internal types ──────────────────────────────────────────────────────────
+
+struct ShortcutTarget {
+    keycode: i64,
+    modifiers: u64,
+}
+
+struct TapContext {
+    target: Arc<Mutex<ShortcutTarget>>,
+    sender: std::sync::mpsc::Sender<()>,
+    tap_ref: *mut c_void,
+}
+
+unsafe impl Send for TapContext {}
+unsafe impl Sync for TapContext {}
+
+// ── Public handle ───────────────────────────────────────────────────────────
+
+/// Stored in Tauri state; allows updating the shortcut at runtime.
+pub struct ShortcutHandle {
+    target: Arc<Mutex<ShortcutTarget>>,
+}
+
+impl ShortcutHandle {
+    /// Update the target shortcut without reinstalling the tap.
+    pub fn update(&self, shortcut_str: &str) -> Result<()> {
+        let (keycode, modifiers) = parse_to_cg(shortcut_str)?;
+        let mut t = self.target.lock().unwrap();
+        t.keycode = keycode;
+        t.modifiers = modifiers;
+        info!("CGEventTap shortcut updated: {}", shortcut_str);
+        Ok(())
+    }
+}
+
+// ── CGEventTap callback ────────────────────────────────────────────────────
+
+unsafe extern "C" fn tap_callback(
+    _proxy: *mut c_void,
+    event_type: u32,
+    event: *mut c_void,
+    user_info: *mut c_void,
+) -> *mut c_void {
+    if user_info.is_null() {
+        return event;
+    }
+
+    let ctx = &*(user_info as *const TapContext);
+
+    // macOS disables the tap if the callback is too slow; re-enable automatically.
+    if event_type == KCG_EVENT_TAP_DISABLED_BY_TIMEOUT {
+        CGEventTapEnable(ctx.tap_ref, true);
+        return event;
+    }
+
+    if event.is_null() || (event_type != KCG_EVENT_KEY_DOWN && event_type != KCG_EVENT_KEY_UP) {
+        return event;
+    }
+
+    let target = match ctx.target.lock() {
+        Ok(t) => t,
+        Err(_) => return event,
+    };
+
+    let keycode = CGEventGetIntegerValueField(event, KCG_KEYBOARD_EVENT_KEYCODE);
+    let flags = CGEventGetFlags(event) & MODIFIER_MASK;
+
+    if keycode == target.keycode && flags == target.modifiers {
+        drop(target);
+        if event_type == KCG_EVENT_KEY_DOWN {
+            let _ = ctx.sender.send(());
+        }
+        // Return null to consume both keyDown and keyUp — other apps never see them.
+        return std::ptr::null_mut();
+    }
+
+    event
+}
+
+// ── Shortcut string → macOS virtual keycode + CG modifier flags ────────────
+
+fn parse_to_cg(shortcut_str: &str) -> Result<(i64, u64)> {
+    let mut mods: u64 = 0;
+    let mut keycode: Option<i64> = None;
+
+    for part in shortcut_str.split('+') {
+        match part.trim() {
+            "Meta" | "Super" | "Cmd" | "Command" => mods |= 1 << 20,
+            "Ctrl" | "Control" => mods |= 1 << 18,
+            "Alt" | "Option" => mods |= 1 << 19,
+            "Shift" => mods |= 1 << 17,
+            key => {
+                keycode = Some(match key {
+                    "Space" => 0x31,
+                    "A" => 0x00, "B" => 0x0B, "C" => 0x08, "D" => 0x02,
+                    "E" => 0x0E, "F" => 0x03, "G" => 0x05, "H" => 0x04,
+                    "I" => 0x22, "J" => 0x26, "K" => 0x28, "L" => 0x25,
+                    "M" => 0x2E, "N" => 0x2D, "O" => 0x1F, "P" => 0x23,
+                    "Q" => 0x0C, "R" => 0x0F, "S" => 0x01, "T" => 0x11,
+                    "U" => 0x20, "V" => 0x09, "W" => 0x0D, "X" => 0x07,
+                    "Y" => 0x10, "Z" => 0x06,
+                    "0" => 0x1D, "1" => 0x12, "2" => 0x13, "3" => 0x14,
+                    "4" => 0x15, "5" => 0x17, "6" => 0x16, "7" => 0x1A,
+                    "8" => 0x1C, "9" => 0x19,
+                    "F1"  => 0x7A, "F2"  => 0x78, "F3"  => 0x63, "F4"  => 0x76,
+                    "F5"  => 0x60, "F6"  => 0x61, "F7"  => 0x62, "F8"  => 0x64,
+                    "F9"  => 0x65, "F10" => 0x6D, "F11" => 0x67, "F12" => 0x6F,
+                    other => bail!("Unknown key: {}", other),
+                });
+            }
+        }
+    }
+
+    let code = keycode.ok_or_else(|| anyhow::anyhow!("Shortcut missing main key"))?;
+    Ok((code, mods))
+}
+
+// ── Public install ──────────────────────────────────────────────────────────
+
+/// Install a CGEventTap at the HID level to intercept the shortcut before any
+/// other app. `on_trigger` is called on each keyDown match from a background
+/// thread. Returns a [`ShortcutHandle`] for runtime updates.
+pub fn install<F>(shortcut_str: &str, on_trigger: F) -> Result<ShortcutHandle>
+where
+    F: Fn() + Send + 'static,
+{
+    let (keycode, modifiers) = parse_to_cg(shortcut_str)?;
+
+    let target = Arc::new(Mutex::new(ShortcutTarget { keycode, modifiers }));
+    let (sender, receiver) = std::sync::mpsc::channel::<()>();
+
+    let handle = ShortcutHandle {
+        target: Arc::clone(&target),
+    };
+
+    let ctx = Box::new(TapContext {
+        target,
+        sender,
+        tap_ref: std::ptr::null_mut(),
+    });
+    let ctx_ptr = Box::into_raw(ctx);
+
+    let event_mask: u64 = (1u64 << KCG_EVENT_KEY_DOWN) | (1u64 << KCG_EVENT_KEY_UP);
+
+    unsafe {
+        let tap = CGEventTapCreate(
+            KCG_HID_EVENT_TAP,
+            KCG_HEAD_INSERT_EVENT_TAP,
+            KCG_EVENT_TAP_OPTION_DEFAULT,
+            event_mask,
+            tap_callback,
+            ctx_ptr as *mut c_void,
+        );
+
+        if tap.is_null() {
+            drop(Box::from_raw(ctx_ptr));
+            bail!(
+                "CGEventTapCreate failed — Accessibility permission may not be granted"
+            );
+        }
+
+        (*ctx_ptr).tap_ref = tap;
+
+        let source = CFMachPortCreateRunLoopSource(std::ptr::null(), tap, 0);
+        if source.is_null() {
+            drop(Box::from_raw(ctx_ptr));
+            bail!("CFMachPortCreateRunLoopSource failed");
+        }
+
+        // Cast to usize so the closure is Send (raw pointers aren't Send).
+        // Safety: these CF objects are thread-safe; we only use them on the new thread.
+        let tap_addr = tap as usize;
+        let source_addr = source as usize;
+        let modes_addr = kCFRunLoopCommonModes as usize;
+        std::thread::spawn(move || {
+            let tap = tap_addr as *mut c_void;
+            let source = source_addr as *mut c_void;
+            let modes = modes_addr as *const c_void;
+            let rl = CFRunLoopGetCurrent();
+            CFRunLoopAddSource(rl, source, modes);
+            CGEventTapEnable(tap, true);
+            info!("CGEventTap run loop started (HID-level shortcut interception active)");
+            CFRunLoopRun();
+        });
+    }
+
+    std::thread::spawn(move || {
+        while receiver.recv().is_ok() {
+            on_trigger();
+        }
+    });
+
+    Ok(handle)
+}

--- a/src-tauri/src/screenshot.rs
+++ b/src-tauri/src/screenshot.rs
@@ -8,7 +8,7 @@ use tracing::{info, warn};
 /// Returns None if capture fails (e.g., Screen Recording permission denied).
 pub fn capture_primary_screen() -> Option<String> {
     let screens = Screen::all()
-        .map_err(|e| warn!("无法获取屏幕列表: {}", e))
+        .map_err(|e| warn!("Cannot get screen list: {}", e))
         .ok()?;
 
     let screen = screens
@@ -18,7 +18,7 @@ pub fn capture_primary_screen() -> Option<String> {
 
     let image = screen
         .capture()
-        .map_err(|e| warn!("截图失败 (可能缺少屏幕录制权限): {}", e))
+        .map_err(|e| warn!("Screenshot failed (may lack Screen Recording permission): {}", e))
         .ok()?;
 
     let width = image.width();
@@ -38,12 +38,12 @@ pub fn capture_primary_screen() -> Option<String> {
     let mut buf = Cursor::new(Vec::new());
     resized
         .write_to(&mut buf, image::ImageFormat::Jpeg)
-        .map_err(|e| warn!("JPEG 编码失败: {}", e))
+        .map_err(|e| warn!("JPEG encoding failed: {}", e))
         .ok()?;
 
     let jpeg_bytes = buf.into_inner();
     info!(
-        "截图完成: {}x{} → {} bytes JPEG",
+        "Screenshot done: {}x{} → {} bytes JPEG",
         width,
         height,
         jpeg_bytes.len()

--- a/src-tauri/src/shortcut.rs
+++ b/src-tauri/src/shortcut.rs
@@ -67,13 +67,13 @@ pub fn parse_shortcut(s: &str) -> Result<Shortcut> {
                     "F10" => Code::F10,
                     "F11" => Code::F11,
                     "F12" => Code::F12,
-                    other => bail!("未知按键: {}", other),
+                    other => bail!("Unknown key: {}", other),
                 });
             }
         }
     }
 
-    let code = key_code.context("快捷键中缺少主键")?;
+    let code = key_code.context("Shortcut missing main key")?;
     Ok(Shortcut::new(Some(mods), code))
 }
 
@@ -81,13 +81,24 @@ pub fn reregister_shortcut<R: Runtime>(
     app: &tauri::AppHandle<R>,
     shortcut_str: &str,
 ) -> Result<()> {
+    // On macOS, prefer updating the CGEventTap (HID-level) — it overrides other apps.
+    #[cfg(target_os = "macos")]
+    {
+        use tauri::Manager;
+        if let Some(handle) = app.try_state::<crate::macos_shortcut::ShortcutHandle>() {
+            handle.update(shortcut_str)?;
+            info!("Shortcut re-registered (CGEventTap): {}", shortcut_str);
+            return Ok(());
+        }
+    }
+
+    // Fallback: Tauri Carbon-based global-shortcut (Windows/Linux, or macOS without AX)
     use crate::commands::RecorderState;
     use crate::state::SharedState;
     use std::sync::Arc;
     use tauri::Manager;
     use tauri_plugin_global_shortcut::ShortcutState;
 
-    // Unregister all existing shortcuts
     let _ = app.global_shortcut().unregister_all();
 
     let shortcut = parse_shortcut(shortcut_str)?;
@@ -107,8 +118,8 @@ pub fn reregister_shortcut<R: Runtime>(
                 });
             }
         })
-        .context("注册快捷键失败")?;
+        .context("Failed to register shortcut")?;
 
-    info!("快捷键重新注册: {}", shortcut_str);
+    info!("Shortcut re-registered (Carbon): {}", shortcut_str);
     Ok(())
 }

--- a/src-tauri/src/transcription/groq.rs
+++ b/src-tauri/src/transcription/groq.rs
@@ -29,24 +29,24 @@ impl GroqClient {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(30))
             .build()
-            .expect("无法创建 HTTP 客户端");
+            .expect("Failed to create HTTP client");
 
         GroqClient { api_key, client }
     }
 
     pub async fn transcribe(&self, wav_bytes: Vec<u8>) -> Result<String> {
-        // 不发送空/过短录音（< 0.1秒 = < 1600 bytes for 16kHz 16-bit mono）
+        // Skip empty/too-short recordings (< 0.1s = < 1600 bytes for 16kHz 16-bit mono)
         if wav_bytes.len() < 1600 {
-            warn!("录音太短，跳过转录");
+            warn!("Recording too short, skipping transcription");
             return Ok(String::new());
         }
 
-        info!("发送 {} bytes 到 Groq Whisper API", wav_bytes.len());
+        info!("Sending {} bytes to Groq Whisper API", wav_bytes.len());
 
         let file_part = multipart::Part::bytes(wav_bytes)
             .file_name("audio.wav")
             .mime_str("audio/wav")
-            .context("设置 MIME 类型失败")?;
+            .context("Failed to set MIME type")?;
 
         let form = multipart::Form::new()
             .part("file", file_part)
@@ -61,23 +61,23 @@ impl GroqClient {
             .multipart(form)
             .send()
             .await
-            .context("请求 Groq API 失败")?;
+            .context("Groq API request failed")?;
 
         let status = resp.status();
-        let body = resp.text().await.context("读取响应失败")?;
+        let body = resp.text().await.context("Failed to read response")?;
 
         if !status.is_success() {
             let err_msg = serde_json::from_str::<GroqError>(&body)
                 .map(|e| e.error.message)
                 .unwrap_or_else(|_| format!("HTTP {}: {}", status, body));
-            bail!("Groq API 错误: {}", err_msg);
+            bail!("Groq API error: {}", err_msg);
         }
 
         let result: GroqResponse =
-            serde_json::from_str(&body).context("解析转录响应失败")?;
+            serde_json::from_str(&body).context("Failed to parse transcription response")?;
 
         let text = result.text.trim().to_string();
-        info!("转录结果: {:?}", text);
+        info!("Transcription result: {:?}", text);
         Ok(text)
     }
 }

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -1,3 +1,5 @@
 pub mod groq;
 pub mod polish;
+pub mod vertex;
 pub use groq::GroqClient;
+pub use vertex::VertexClient;

--- a/src-tauri/src/transcription/polish.rs
+++ b/src-tauri/src/transcription/polish.rs
@@ -93,15 +93,15 @@ pub async fn polish_text(text: &str, api_key: &str, screenshot: Option<&str>) ->
     let max_tokens = compute_max_tokens(original_len);
 
     if let Some(img_data) = screenshot {
-        info!("使用视觉模型润色 (截图上下文已附加)");
+        info!("Using vision model for polish (screenshot context attached)");
         match try_polish_vision(text, api_key, img_data, 0.1, false, max_tokens).await {
             Ok(polished) if polished.chars().count() >= threshold => {
-                info!("视觉模型润色完成");
+                info!("Vision model polish complete");
                 return (polished, false);
             }
             Ok(short) => {
                 warn!(
-                    "视觉模型润色结果字数({})低于阈值({}), 重试",
+                    "Vision polish result too short ({}/{} chars), retrying",
                     short.chars().count(),
                     threshold
                 );
@@ -109,14 +109,14 @@ pub async fn polish_text(text: &str, api_key: &str, screenshot: Option<&str>) ->
                     try_polish_vision(text, api_key, img_data, 0.3, true, max_tokens).await
                 {
                     if p.chars().count() >= threshold {
-                        info!("视觉模型重试润色成功");
+                        info!("Vision model retry succeeded");
                         return (p, false);
                     }
                 }
-                warn!("视觉模型重试仍失败，降级为纯文字润色");
+                warn!("Vision model retry failed, falling back to text-only polish");
             }
             Err(e) => {
-                warn!("视觉模型失败: {}，降级为纯文字润色", e);
+                warn!("Vision model failed: {}, falling back to text-only polish", e);
             }
         }
     }
@@ -124,35 +124,35 @@ pub async fn polish_text(text: &str, api_key: &str, screenshot: Option<&str>) ->
     // Text-only path (either no screenshot or vision failed)
     match try_polish_text(text, api_key, PRIMARY_MODEL, 0.1, false, max_tokens).await {
         Ok(polished) if polished.chars().count() >= threshold => {
-            info!("润色完成");
+            info!("Polish complete");
             (polished, false)
         }
         Ok(short) => {
             warn!(
-                "润色结果字数({})低于阈值({}), 重试",
+                "Polish result too short ({}/{} chars), retrying",
                 short.chars().count(),
                 threshold
             );
             match try_polish_text(text, api_key, PRIMARY_MODEL, 0.3, true, max_tokens).await {
                 Ok(p) if p.chars().count() >= threshold => {
-                    info!("重试润色成功");
+                    info!("Polish retry succeeded");
                     (p, false)
                 }
                 Ok(_) | Err(_) => {
-                    warn!("重试润色仍失败，返回原始文本");
+                    warn!("Polish retry still failed, returning original text");
                     (text.to_string(), true)
                 }
             }
         }
         Err(e) => {
-            warn!("主模型润色失败: {}，尝试备用模型 {}", e, FALLBACK_MODEL);
+            warn!("Primary model polish failed: {}, trying fallback model {}", e, FALLBACK_MODEL);
             match try_polish_text(text, api_key, FALLBACK_MODEL, 0.1, false, max_tokens).await {
                 Ok(p) if p.chars().count() >= threshold => {
-                    info!("备用模型润色成功");
+                    info!("Fallback model polish succeeded");
                     (p, false)
                 }
                 Ok(_) | Err(_) => {
-                    warn!("备用模型润色失败，返回原始文本");
+                    warn!("Fallback model polish failed, returning original text");
                     (text.to_string(), true)
                 }
             }
@@ -272,7 +272,7 @@ async fn send_request(
     let body = resp.text().await?;
 
     if !status.is_success() {
-        anyhow::bail!("Groq 润色 API 错误: HTTP {} {}", status, body);
+        anyhow::bail!("Groq polish API error: HTTP {} {}", status, body);
     }
 
     let response: ChatResponse = serde_json::from_str(&body)?;
@@ -284,7 +284,7 @@ async fn send_request(
         .unwrap_or_default();
 
     if polished.is_empty() {
-        anyhow::bail!("润色返回空内容");
+        anyhow::bail!("Polish returned empty content");
     }
 
     Ok(polished)

--- a/src-tauri/src/transcription/polish.rs
+++ b/src-tauri/src/transcription/polish.rs
@@ -65,14 +65,14 @@ fn compute_max_tokens(char_count: usize) -> u32 {
     ((char_count as u32 * 3 / 2) + 256).max(512).min(65_536)
 }
 
-const SYSTEM_PROMPT_TEXT: &str = "You are a transcription cleanup assistant. \
+pub(crate) const SYSTEM_PROMPT_TEXT: &str = "You are a transcription cleanup assistant. \
     For speech-to-text output: \
     1) Add punctuation and sentence breaks \
     2) Fix obvious speech recognition errors (homophones, mishearing) \
     3) Preserve the original meaning without rewriting. \
     Output only the cleaned text, no explanations. Respond in the same language as the input.";
 
-const SYSTEM_PROMPT_VISION: &str = "You are a transcription cleanup assistant with access to a \
+pub(crate) const SYSTEM_PROMPT_VISION: &str = "You are a transcription cleanup assistant with access to a \
     screenshot of the user's current screen for context. \
     Use visible text — especially brand names, product names, and technical terms — as a \
     reference when the transcription contains a word that sounds similar but may be a \

--- a/src-tauri/src/transcription/vertex.rs
+++ b/src-tauri/src/transcription/vertex.rs
@@ -1,0 +1,375 @@
+use anyhow::{bail, Context, Result};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use reqwest::Client;
+use serde::Deserialize;
+use std::time::Duration;
+use tracing::{info, warn};
+
+use super::polish::{SYSTEM_PROMPT_TEXT, SYSTEM_PROMPT_VISION};
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: String,
+}
+
+pub struct VertexClient {
+    project_id: String,
+    location: String,
+    model: String,
+    access_token: String,
+    client: Client,
+}
+
+impl VertexClient {
+    pub async fn new(project_id: String, location: String, model: String) -> Result<Self> {
+        let access_token = get_access_token().await?;
+        let client = Client::builder()
+            .timeout(Duration::from_secs(60))
+            .build()
+            .context("无法创建 HTTP 客户端")?;
+
+        Ok(VertexClient {
+            project_id,
+            location,
+            model,
+            access_token,
+            client,
+        })
+    }
+
+    fn gemini_url(&self, model: &str) -> String {
+        format!(
+            "https://{loc}-aiplatform.googleapis.com/v1/projects/{proj}/locations/{loc}/publishers/google/models/{model}:generateContent",
+            loc = self.location,
+            proj = self.project_id,
+        )
+    }
+
+    pub async fn transcribe(&self, wav_bytes: Vec<u8>) -> Result<String> {
+        if wav_bytes.len() < 1600 {
+            warn!("录音太短，跳过转录");
+            return Ok(String::new());
+        }
+
+        info!(
+            "发送 {} bytes 到 Vertex AI Gemini ({}) 转录",
+            wav_bytes.len(),
+            self.model
+        );
+
+        let audio_base64 = BASE64.encode(&wav_bytes);
+
+        let body = serde_json::json!({
+            "contents": [{
+                "role": "user",
+                "parts": [
+                    {
+                        "inlineData": {
+                            "mimeType": "audio/wav",
+                            "data": audio_base64
+                        }
+                    },
+                    {
+                        "text": "Transcribe this audio exactly as spoken. Output only the transcribed text, nothing else. Respond in the same language as the audio."
+                    }
+                ]
+            }],
+            "generationConfig": {
+                "temperature": 0.0,
+                "maxOutputTokens": 8192
+            }
+        });
+
+        let text =
+            send_gemini_request(&self.client, &self.gemini_url(&self.model), &self.access_token, &body).await?;
+
+        info!("Vertex AI 转录结果: {:?}", text);
+        Ok(text)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Polish via Vertex AI Gemini
+// ---------------------------------------------------------------------------
+
+pub async fn polish_text_vertex(
+    text: &str,
+    project_id: &str,
+    location: &str,
+    model: &str,
+    screenshot: Option<&str>,
+) -> (String, bool) {
+    let access_token = match get_access_token().await {
+        Ok(t) => t,
+        Err(e) => {
+            warn!("获取 Vertex AI access token 失败: {}", e);
+            return (text.to_string(), true);
+        }
+    };
+
+    let original_len = text.chars().count();
+    let threshold = (original_len as f64 * 0.8) as usize;
+    let max_tokens = ((original_len as u32 * 3 / 2) + 256).max(512).min(65_536);
+
+    let url = format!(
+        "https://{loc}-aiplatform.googleapis.com/v1/projects/{proj}/locations/{loc}/publishers/google/models/{model}:generateContent",
+        loc = location, proj = project_id,
+    );
+
+    let client = Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .unwrap();
+
+    if let Some(img_data) = screenshot {
+        info!("使用 Vertex AI 视觉模型润色 (截图上下文已附加)");
+        match try_vision(&client, &url, &access_token, text, img_data, 0.1, false, max_tokens)
+            .await
+        {
+            Ok(p) if p.chars().count() >= threshold => {
+                info!("Vertex AI 视觉润色完成");
+                return (p, false);
+            }
+            Ok(short) => {
+                warn!(
+                    "视觉润色结果过短({}/{}), 重试",
+                    short.chars().count(),
+                    threshold
+                );
+                if let Ok(p) =
+                    try_vision(&client, &url, &access_token, text, img_data, 0.3, true, max_tokens)
+                        .await
+                {
+                    if p.chars().count() >= threshold {
+                        return (p, false);
+                    }
+                }
+                warn!("视觉润色重试失败，降级为纯文字润色");
+            }
+            Err(e) => {
+                warn!("Vertex AI 视觉模型失败: {}，降级为纯文字润色", e);
+            }
+        }
+    }
+
+    match try_text(&client, &url, &access_token, text, 0.1, false, max_tokens).await {
+        Ok(p) if p.chars().count() >= threshold => {
+            info!("Vertex AI 润色完成");
+            (p, false)
+        }
+        Ok(_) => {
+            match try_text(&client, &url, &access_token, text, 0.3, true, max_tokens).await {
+                Ok(p) if p.chars().count() >= threshold => (p, false),
+                _ => {
+                    warn!("Vertex AI 润色重试失败，返回原始文本");
+                    (text.to_string(), true)
+                }
+            }
+        }
+        Err(e) => {
+            warn!("Vertex AI 润色失败: {}", e);
+            (text.to_string(), true)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async fn try_vision(
+    client: &Client,
+    url: &str,
+    token: &str,
+    text: &str,
+    screenshot_data_url: &str,
+    temperature: f32,
+    with_hint: bool,
+    max_tokens: u32,
+) -> Result<String> {
+    let user_text = if with_hint {
+        format!(
+            "The above screenshot shows the user's current screen (context only).\n\nTranscription to clean up:\n{}\n\n(Please ensure the output is complete and covers all content without truncation.)",
+            text
+        )
+    } else {
+        format!(
+            "The above screenshot shows the user's current screen (context only).\n\nTranscription to clean up:\n{}",
+            text
+        )
+    };
+
+    let mut parts = Vec::new();
+
+    if let Some((mime, b64)) = parse_data_url(screenshot_data_url) {
+        parts.push(serde_json::json!({
+            "inlineData": { "mimeType": mime, "data": b64 }
+        }));
+    }
+    parts.push(serde_json::json!({ "text": user_text }));
+
+    let body = serde_json::json!({
+        "contents": [{ "role": "user", "parts": parts }],
+        "systemInstruction": { "parts": [{ "text": SYSTEM_PROMPT_VISION }] },
+        "generationConfig": { "temperature": temperature, "maxOutputTokens": max_tokens }
+    });
+
+    send_gemini_request(client, url, token, &body).await
+}
+
+async fn try_text(
+    client: &Client,
+    url: &str,
+    token: &str,
+    text: &str,
+    temperature: f32,
+    with_hint: bool,
+    max_tokens: u32,
+) -> Result<String> {
+    let user_text = if with_hint {
+        format!(
+            "{}\n\n(Please ensure the output is complete and covers all content without truncation.)",
+            text
+        )
+    } else {
+        text.to_string()
+    };
+
+    let body = serde_json::json!({
+        "contents": [{ "role": "user", "parts": [{ "text": user_text }] }],
+        "systemInstruction": { "parts": [{ "text": SYSTEM_PROMPT_TEXT }] },
+        "generationConfig": { "temperature": temperature, "maxOutputTokens": max_tokens }
+    });
+
+    send_gemini_request(client, url, token, &body).await
+}
+
+fn parse_data_url(data_url: &str) -> Option<(&str, &str)> {
+    let stripped = data_url.strip_prefix("data:")?;
+    let semicolon = stripped.find(';')?;
+    let mime = &stripped[..semicolon];
+    let base64_data = stripped[semicolon + 1..].strip_prefix("base64,")?;
+    Some((mime, base64_data))
+}
+
+async fn send_gemini_request(
+    client: &Client,
+    url: &str,
+    access_token: &str,
+    body: &serde_json::Value,
+) -> Result<String> {
+    let resp = client
+        .post(url)
+        .bearer_auth(access_token)
+        .json(body)
+        .send()
+        .await?;
+
+    let status = resp.status();
+    let resp_body = resp.text().await?;
+
+    if !status.is_success() {
+        bail!("Vertex AI API 错误: HTTP {} — {}", status, resp_body);
+    }
+
+    let response: serde_json::Value =
+        serde_json::from_str(&resp_body).context("解析 Vertex AI 响应失败")?;
+    let text = response["candidates"][0]["content"]["parts"][0]["text"]
+        .as_str()
+        .unwrap_or("")
+        .trim()
+        .to_string();
+
+    if text.is_empty() {
+        bail!("Vertex AI 返回空内容");
+    }
+
+    Ok(text)
+}
+
+// ---------------------------------------------------------------------------
+// ADC (Application Default Credentials) token management
+// ---------------------------------------------------------------------------
+
+pub fn check_adc_available() -> bool {
+    get_adc_path()
+        .ok()
+        .and_then(|p| std::fs::metadata(&p).ok())
+        .map(|m| m.is_file())
+        .unwrap_or(false)
+}
+
+async fn get_access_token() -> Result<String> {
+    let adc_path = get_adc_path()?;
+    let data = std::fs::read_to_string(&adc_path).with_context(|| {
+        format!(
+            "无法读取 ADC 凭证: {:?}\n请运行: gcloud auth application-default login",
+            adc_path
+        )
+    })?;
+
+    let creds: serde_json::Value =
+        serde_json::from_str(&data).context("解析 ADC 凭证失败")?;
+
+    let cred_type = creds["type"].as_str().unwrap_or("");
+    if cred_type != "authorized_user" {
+        bail!(
+            "仅支持 authorized_user 类型的凭证 (当前: {})\n请运行: gcloud auth application-default login",
+            cred_type
+        );
+    }
+
+    let client_id = creds["client_id"].as_str().context("ADC 缺少 client_id")?;
+    let client_secret = creds["client_secret"]
+        .as_str()
+        .context("ADC 缺少 client_secret")?;
+    let refresh_token = creds["refresh_token"]
+        .as_str()
+        .context("ADC 缺少 refresh_token")?;
+
+    let client = Client::new();
+    let resp = client
+        .post("https://oauth2.googleapis.com/token")
+        .form(&[
+            ("grant_type", "refresh_token"),
+            ("client_id", client_id),
+            ("client_secret", client_secret),
+            ("refresh_token", refresh_token),
+        ])
+        .send()
+        .await
+        .context("请求 Google OAuth token 失败")?;
+
+    if !resp.status().is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        bail!("获取 access token 失败: {}", body);
+    }
+
+    let token: TokenResponse = resp.json().await.context("解析 token 响应失败")?;
+    Ok(token.access_token)
+}
+
+fn get_adc_path() -> Result<std::path::PathBuf> {
+    if let Ok(path) = std::env::var("GOOGLE_APPLICATION_CREDENTIALS") {
+        return Ok(std::path::PathBuf::from(path));
+    }
+
+    let home = dirs::home_dir().context("无法获取 home 目录")?;
+
+    #[cfg(target_os = "windows")]
+    {
+        Ok(home
+            .join("AppData")
+            .join("Roaming")
+            .join("gcloud")
+            .join("application_default_credentials.json"))
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        Ok(home
+            .join(".config")
+            .join("gcloud")
+            .join("application_default_credentials.json"))
+    }
+}

--- a/src-tauri/src/transcription/vertex.rs
+++ b/src-tauri/src/transcription/vertex.rs
@@ -26,7 +26,7 @@ impl VertexClient {
         let client = Client::builder()
             .timeout(Duration::from_secs(60))
             .build()
-            .context("无法创建 HTTP 客户端")?;
+            .context("Failed to create HTTP client")?;
 
         Ok(VertexClient {
             project_id,
@@ -47,12 +47,12 @@ impl VertexClient {
 
     pub async fn transcribe(&self, wav_bytes: Vec<u8>) -> Result<String> {
         if wav_bytes.len() < 1600 {
-            warn!("录音太短，跳过转录");
+            warn!("Recording too short, skipping transcription");
             return Ok(String::new());
         }
 
         info!(
-            "发送 {} bytes 到 Vertex AI Gemini ({}) 转录",
+            "Sending {} bytes to Vertex AI Gemini ({}) for transcription",
             wav_bytes.len(),
             self.model
         );
@@ -83,7 +83,7 @@ impl VertexClient {
         let text =
             send_gemini_request(&self.client, &self.gemini_url(&self.model), &self.access_token, &body).await?;
 
-        info!("Vertex AI 转录结果: {:?}", text);
+        info!("Vertex AI transcription result: {:?}", text);
         Ok(text)
     }
 }
@@ -102,7 +102,7 @@ pub async fn polish_text_vertex(
     let access_token = match get_access_token().await {
         Ok(t) => t,
         Err(e) => {
-            warn!("获取 Vertex AI access token 失败: {}", e);
+            warn!("Failed to get Vertex AI access token: {}", e);
             return (text.to_string(), true);
         }
     };
@@ -122,17 +122,17 @@ pub async fn polish_text_vertex(
         .unwrap();
 
     if let Some(img_data) = screenshot {
-        info!("使用 Vertex AI 视觉模型润色 (截图上下文已附加)");
+        info!("Using Vertex AI vision model for polish (screenshot attached)");
         match try_vision(&client, &url, &access_token, text, img_data, 0.1, false, max_tokens)
             .await
         {
             Ok(p) if p.chars().count() >= threshold => {
-                info!("Vertex AI 视觉润色完成");
+                info!("Vertex AI vision polish complete");
                 return (p, false);
             }
             Ok(short) => {
                 warn!(
-                    "视觉润色结果过短({}/{}), 重试",
+                    "Vision polish result too short ({}/{}), retrying",
                     short.chars().count(),
                     threshold
                 );
@@ -144,30 +144,30 @@ pub async fn polish_text_vertex(
                         return (p, false);
                     }
                 }
-                warn!("视觉润色重试失败，降级为纯文字润色");
+                warn!("Vision polish retry failed, falling back to text-only");
             }
             Err(e) => {
-                warn!("Vertex AI 视觉模型失败: {}，降级为纯文字润色", e);
+                warn!("Vertex AI vision model failed: {}, falling back to text-only", e);
             }
         }
     }
 
     match try_text(&client, &url, &access_token, text, 0.1, false, max_tokens).await {
         Ok(p) if p.chars().count() >= threshold => {
-            info!("Vertex AI 润色完成");
+            info!("Vertex AI polish complete");
             (p, false)
         }
         Ok(_) => {
             match try_text(&client, &url, &access_token, text, 0.3, true, max_tokens).await {
                 Ok(p) if p.chars().count() >= threshold => (p, false),
                 _ => {
-                    warn!("Vertex AI 润色重试失败，返回原始文本");
+                    warn!("Vertex AI polish retry failed, returning original text");
                     (text.to_string(), true)
                 }
             }
         }
         Err(e) => {
-            warn!("Vertex AI 润色失败: {}", e);
+            warn!("Vertex AI polish failed: {}", e);
             (text.to_string(), true)
         }
     }
@@ -269,11 +269,11 @@ async fn send_gemini_request(
     let resp_body = resp.text().await?;
 
     if !status.is_success() {
-        bail!("Vertex AI API 错误: HTTP {} — {}", status, resp_body);
+        bail!("Vertex AI API error: HTTP {} — {}", status, resp_body);
     }
 
     let response: serde_json::Value =
-        serde_json::from_str(&resp_body).context("解析 Vertex AI 响应失败")?;
+        serde_json::from_str(&resp_body).context("Failed to parse Vertex AI response")?;
     let text = response["candidates"][0]["content"]["parts"][0]["text"]
         .as_str()
         .unwrap_or("")
@@ -281,7 +281,7 @@ async fn send_gemini_request(
         .to_string();
 
     if text.is_empty() {
-        bail!("Vertex AI 返回空内容");
+        bail!("Vertex AI returned empty content");
     }
 
     Ok(text)
@@ -303,29 +303,29 @@ async fn get_access_token() -> Result<String> {
     let adc_path = get_adc_path()?;
     let data = std::fs::read_to_string(&adc_path).with_context(|| {
         format!(
-            "无法读取 ADC 凭证: {:?}\n请运行: gcloud auth application-default login",
+            "Cannot read ADC credentials: {:?}\nRun: gcloud auth application-default login",
             adc_path
         )
     })?;
 
     let creds: serde_json::Value =
-        serde_json::from_str(&data).context("解析 ADC 凭证失败")?;
+        serde_json::from_str(&data).context("Failed to parse ADC credentials")?;
 
     let cred_type = creds["type"].as_str().unwrap_or("");
     if cred_type != "authorized_user" {
         bail!(
-            "仅支持 authorized_user 类型的凭证 (当前: {})\n请运行: gcloud auth application-default login",
+            "Only authorized_user credential type is supported (current: {})\nRun: gcloud auth application-default login",
             cred_type
         );
     }
 
-    let client_id = creds["client_id"].as_str().context("ADC 缺少 client_id")?;
+    let client_id = creds["client_id"].as_str().context("ADC missing client_id")?;
     let client_secret = creds["client_secret"]
         .as_str()
-        .context("ADC 缺少 client_secret")?;
+        .context("ADC missing client_secret")?;
     let refresh_token = creds["refresh_token"]
         .as_str()
-        .context("ADC 缺少 refresh_token")?;
+        .context("ADC missing refresh_token")?;
 
     let client = Client::new();
     let resp = client
@@ -338,14 +338,14 @@ async fn get_access_token() -> Result<String> {
         ])
         .send()
         .await
-        .context("请求 Google OAuth token 失败")?;
+        .context("Failed to request Google OAuth token")?;
 
     if !resp.status().is_success() {
         let body = resp.text().await.unwrap_or_default();
-        bail!("获取 access token 失败: {}", body);
+        bail!("Failed to get access token: {}", body);
     }
 
-    let token: TokenResponse = resp.json().await.context("解析 token 响应失败")?;
+    let token: TokenResponse = resp.json().await.context("Failed to parse token response")?;
     Ok(token.access_token)
 }
 
@@ -354,7 +354,7 @@ fn get_adc_path() -> Result<std::path::PathBuf> {
         return Ok(std::path::PathBuf::from(path));
     }
 
-    let home = dirs::home_dir().context("无法获取 home 目录")?;
+    let home = dirs::home_dir().context("Cannot determine home directory")?;
 
     #[cfg(target_os = "windows")]
     {

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -52,6 +52,7 @@ pub fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
                     let _ = crate::config::AppConfig::save(app, &cfg);
                 }
                 info!("AI polish: {}", if new_enabled { "on" } else { "off" });
+                let _ = app.emit("polish-changed", new_enabled);
                 // Rebuild menu to refresh check state
                 if let Some(tray) = app.tray_by_id("main-tray") {
                     if let Ok(menu) = build_tray_menu(app, new_enabled) {
@@ -77,7 +78,7 @@ pub fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
     Ok(())
 }
 
-fn build_tray_menu<R: Runtime>(app: &AppHandle<R>, polish_enabled: bool) -> tauri::Result<Menu<R>> {
+pub fn build_tray_menu<R: Runtime>(app: &AppHandle<R>, polish_enabled: bool) -> tauri::Result<Menu<R>> {
     let last     = MenuItem::with_id(app, "last-result", "No transcription yet", false, None::<&str>)?;
     let sep1     = PredefinedMenuItem::separator(app)?;
     let polish   = CheckMenuItem::with_id(app, "toggle-polish", "AI Polish", true, polish_enabled, None::<&str>)?;

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -19,7 +19,7 @@ pub fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
     TrayIconBuilder::with_id("main-tray")
         .icon(idle_icon())
         .icon_as_template(true)
-        .tooltip("Audio Input — 点击或 ⌘⇧Space 开始录音")
+        .tooltip("Audio Input — Click or ⌘⇧Space to record")
         .menu(&menu)
         .show_menu_on_left_click(false)
         .on_menu_event(|app, event| match event.id.as_ref() {
@@ -78,14 +78,14 @@ pub fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
 }
 
 fn build_tray_menu<R: Runtime>(app: &AppHandle<R>, polish_enabled: bool) -> tauri::Result<Menu<R>> {
-    let last     = MenuItem::with_id(app, "last-result", "尚无转录结果", false, None::<&str>)?;
+    let last     = MenuItem::with_id(app, "last-result", "No transcription yet", false, None::<&str>)?;
     let sep1     = PredefinedMenuItem::separator(app)?;
-    let polish   = CheckMenuItem::with_id(app, "toggle-polish", "AI 润色", true, polish_enabled, None::<&str>)?;
+    let polish   = CheckMenuItem::with_id(app, "toggle-polish", "AI Polish", true, polish_enabled, None::<&str>)?;
     let sep2     = PredefinedMenuItem::separator(app)?;
-    let settings = MenuItem::with_id(app, "settings", "设置...", true, None::<&str>)?;
-    let open_log = MenuItem::with_id(app, "open-log", "打开日志文件", true, None::<&str>)?;
+    let settings = MenuItem::with_id(app, "settings", "Settings…", true, None::<&str>)?;
+    let open_log = MenuItem::with_id(app, "open-log", "Open Log File", true, None::<&str>)?;
     let sep3     = PredefinedMenuItem::separator(app)?;
-    let quit     = MenuItem::with_id(app, "quit", "退出", true, None::<&str>)?;
+    let quit     = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
 
     Menu::with_items(app, &[&last, &sep1, &polish, &sep2, &settings, &open_log, &sep3, &quit])
 }
@@ -110,7 +110,7 @@ pub fn set_tray_last_result<R: Runtime>(app: &AppHandle<R>, text: &str) {
         } else {
             text.to_string()
         };
-        let _ = tray.set_tooltip(Some(format!("最近转录: {}", display)));
+        let _ = tray.set_tooltip(Some(format!("Last: {}", display)));
     }
 }
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -24,7 +24,7 @@ pub fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
         .show_menu_on_left_click(false)
         .on_menu_event(|app, event| match event.id.as_ref() {
             "quit" => {
-                info!("用户退出");
+                info!("User quit");
                 app.exit(0);
             }
             "settings" => {
@@ -51,8 +51,8 @@ pub fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
                     let cfg = config_state.lock().unwrap();
                     let _ = crate::config::AppConfig::save(app, &cfg);
                 }
-                info!("AI 润色: {}", if new_enabled { "开启" } else { "关闭" });
-                // 重建菜单以刷新勾选状态
+                info!("AI polish: {}", if new_enabled { "on" } else { "off" });
+                // Rebuild menu to refresh check state
                 if let Some(tray) = app.tray_by_id("main-tray") {
                     if let Ok(menu) = build_tray_menu(app, new_enabled) {
                         let _ = tray.set_menu(Some(menu));
@@ -126,17 +126,17 @@ fn show_settings_window<R: Runtime>(app: &AppHandle<R>) {
     }
 }
 
-// --- 内嵌图标 ---
+// --- Embedded icons ---
 
 fn idle_icon() -> Image<'static> {
-    Image::from_bytes(include_bytes!("../icons/tray-idle.png")).expect("tray-idle.png 损坏")
+    Image::from_bytes(include_bytes!("../icons/tray-idle.png")).expect("tray-idle.png corrupted")
 }
 fn recording_icon() -> Image<'static> {
-    Image::from_bytes(include_bytes!("../icons/tray-recording.png")).expect("tray-recording.png 损坏")
+    Image::from_bytes(include_bytes!("../icons/tray-recording.png")).expect("tray-recording.png corrupted")
 }
 fn processing_icon() -> Image<'static> {
-    Image::from_bytes(include_bytes!("../icons/tray-processing.png")).expect("tray-processing.png 损坏")
+    Image::from_bytes(include_bytes!("../icons/tray-processing.png")).expect("tray-processing.png corrupted")
 }
 fn error_icon() -> Image<'static> {
-    Image::from_bytes(include_bytes!("../icons/tray-error.png")).expect("tray-error.png 损坏")
+    Image::from_bytes(include_bytes!("../icons/tray-error.png")).expect("tray-error.png corrupted")
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Audio Input",
-  "version": "0.2.0",
+  "version": "0.3.5",
   "identifier": "com.audioinput.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -43,6 +43,7 @@
   import RecordingIndicator from "./lib/RecordingIndicator.svelte";
   import SettingsPanel from "./lib/SettingsPanel.svelte";
   import OnboardingFlow from "./lib/OnboardingFlow.svelte";
+  import { t } from "./lib/i18n";
 
   type AppState = "idle" | "recording" | "processing" | "error";
 
@@ -142,7 +143,7 @@
     // 监听辅助功能权限缺失
     unlisten.push(
       await listen("accessibility-missing", () => {
-        errorMsg = "请在系统设置中授予辅助功能权限";
+        errorMsg = "Accessibility permission required";
         appState = "error";
         appWindow.show();
       })
@@ -216,12 +217,12 @@
         </svg>
       </div>
       <div class="ax-text">
-        <p>需要<strong>辅助功能</strong>权限才能自动注入文字</p>
-        <p class="hint">授权后请完全退出并重启 App</p>
+        <p>{$t('ax.need')}</p>
+        <p class="hint">{$t('ax.restart')}</p>
       </div>
       <div class="ax-buttons">
-        <button class="primary" on:click={() => invoke("open_accessibility_prefs")}>打开系统设置</button>
-        <button on:click={() => (needsAccessibilityRestart = false)}>忽略</button>
+        <button class="primary" on:click={() => invoke("open_accessibility_prefs")}>{$t('ax.open')}</button>
+        <button on:click={() => (needsAccessibilityRestart = false)}>{$t('ax.dismiss')}</button>
       </div>
     </div>
   {:else if showSettings}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -62,6 +62,7 @@
   let audioDevices: string[] = [];
   let autostartEnabled = false;
   let screenshotContextEnabled = false;
+  let windowOpacity = parseFloat(localStorage.getItem("window-opacity") || "1");
 
   const appWindow = getCurrentWindow();
   const unlisten: UnlistenFn[] = [];
@@ -85,12 +86,6 @@
       resizeTo(AX_W, AX_H);
     }
 
-    // Restore window opacity
-    const savedOpacity = localStorage.getItem("window-opacity");
-    if (savedOpacity) {
-      document.documentElement.style.opacity = savedOpacity;
-    }
-
     // Load settings data
     polishEnabled = await invoke<boolean>("get_polish_enabled").catch(() => true);
     audioDevices = await invoke<string[]>("list_audio_devices").catch(() => []);
@@ -107,10 +102,12 @@
             showSettings = false;
           }
           resizeTo(HUD_W, HUD_H, HUD_POS_KEY);
-        } else if (e.payload === "idle" && !showSettings && !injectionFailed && !needsAccessibilityRestart) {
-          setTimeout(() => appWindow.hide(), 800);
-        } else if (e.payload === "idle") {
-          injectionFailed = false;
+        } else if (e.payload === "idle" && !showSettings && !needsAccessibilityRestart) {
+          if (injectionFailed || polishFailed) {
+            setTimeout(() => { injectionFailed = false; appWindow.hide(); }, 1500);
+          } else {
+            appWindow.hide();
+          }
         }
       })
     );
@@ -220,7 +217,7 @@
   }
 </script>
 
-<div class="container" class:panel-mode={showSettings || showOnboarding}>
+<div class="container" class:panel-mode={showSettings || showOnboarding} style={windowOpacity < 1 ? `opacity:${windowOpacity}` : ''}>
   {#if showOnboarding}
     <OnboardingFlow on:done={handleOnboardingDone} />
   {:else if needsAccessibilityRestart}
@@ -244,6 +241,7 @@
   {:else if showSettings}
     <SettingsPanel
       bind:polishEnabled
+      bind:windowOpacity
       {audioDevices}
       bind:autostartEnabled
       bind:screenshotContextEnabled
@@ -264,8 +262,10 @@
     padding: 0;
   }
 
-  :global(body) {
+  :global(html), :global(body) {
     background: transparent;
+  }
+  :global(body) {
     font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
     -webkit-font-smoothing: antialiased;
     user-select: none;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -6,7 +6,8 @@
   import { LogicalSize, LogicalPosition } from "@tauri-apps/api/dpi";
 
   const HUD_W = 200, HUD_H = 44;
-  const PANEL_W = 340, PANEL_H = 620;
+  const SETTINGS_W = 340, SETTINGS_H = 620;
+  const ONBOARDING_W = 370, ONBOARDING_H = 540;
   const AX_W = 320, AX_H = 160;
 
   const HUD_POS_KEY = "hud-window-pos";
@@ -53,6 +54,7 @@
   let needsAccessibilityRestart = false;
   let showOnboarding = false;
   let polishFailed = false;
+  let shortcutConflict = "";
 
   // Settings data
   let polishEnabled = true;
@@ -68,7 +70,7 @@
     const onboardingDone = await invoke<boolean>("get_onboarding_completed").catch(() => true);
     if (!onboardingDone) {
       showOnboarding = true;
-      resizeTo(PANEL_W, PANEL_H);
+      resizeTo(ONBOARDING_W, ONBOARDING_H);
     }
 
     // 获取当前状态
@@ -124,7 +126,7 @@
       await listen("api-key-missing", async () => {
         await savePos(HUD_POS_KEY);
         showSettings = true;
-        await resizeTo(PANEL_W, PANEL_H, SETTINGS_POS_KEY);
+        await resizeTo(SETTINGS_W, SETTINGS_H, SETTINGS_POS_KEY);
       })
     );
 
@@ -133,7 +135,7 @@
       await listen("show-settings", async () => {
         await savePos(HUD_POS_KEY);
         showSettings = true;
-        await resizeTo(PANEL_W, PANEL_H, SETTINGS_POS_KEY);
+        await resizeTo(SETTINGS_W, SETTINGS_H, SETTINGS_POS_KEY);
       })
     );
 
@@ -151,6 +153,16 @@
       await listen("polish-failed", () => {
         polishFailed = true;
         setTimeout(() => { polishFailed = false; }, 3000);
+      })
+    );
+
+    // 监听快捷键冲突
+    unlisten.push(
+      await listen<string>("shortcut-conflict", async (e) => {
+        shortcutConflict = e.payload;
+        await savePos(HUD_POS_KEY);
+        showSettings = true;
+        await resizeTo(SETTINGS_W, SETTINGS_H, SETTINGS_POS_KEY);
       })
     );
   });
@@ -219,6 +231,7 @@
       bind:autostartEnabled
       bind:screenshotContextEnabled
       appState={appState}
+      bind:shortcutConflict
       on:saved={handleSettingsSaved}
       on:close={handleSettingsClosed}
     />

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -62,12 +62,16 @@
   let audioDevices: string[] = [];
   let autostartEnabled = false;
   let screenshotContextEnabled = false;
-  let windowOpacity = parseFloat(localStorage.getItem("window-opacity") || "1");
 
   const appWindow = getCurrentWindow();
   const unlisten: UnlistenFn[] = [];
 
   onMount(async () => {
+    // Clear stale inline styles left by previous HMR cycles
+    document.documentElement.removeAttribute('style');
+    document.body.removeAttribute('style');
+    localStorage.removeItem('window-opacity');
+
     // Check onboarding
     const onboardingDone = await invoke<boolean>("get_onboarding_completed").catch(() => true);
     if (!onboardingDone) {
@@ -100,6 +104,7 @@
           if (showSettings) {
             savePos(SETTINGS_POS_KEY);
             showSettings = false;
+            invoke("set_native_opaque", { opaque: false });
           }
           resizeTo(HUD_W, HUD_H, HUD_POS_KEY);
         } else if (e.payload === "idle" && !showSettings && !needsAccessibilityRestart) {
@@ -134,6 +139,7 @@
       await listen("api-key-missing", async () => {
         await savePos(HUD_POS_KEY);
         showSettings = true;
+        await invoke("set_native_opaque", { opaque: true });
         await resizeTo(SETTINGS_W, SETTINGS_H, SETTINGS_POS_KEY);
       })
     );
@@ -143,6 +149,7 @@
       await listen("show-settings", async () => {
         await savePos(HUD_POS_KEY);
         showSettings = true;
+        await invoke("set_native_opaque", { opaque: true });
         await resizeTo(SETTINGS_W, SETTINGS_H, SETTINGS_POS_KEY);
       })
     );
@@ -176,6 +183,7 @@
         shortcutConflict = e.payload;
         await savePos(HUD_POS_KEY);
         showSettings = true;
+        await invoke("set_native_opaque", { opaque: true });
         await resizeTo(SETTINGS_W, SETTINGS_H, SETTINGS_POS_KEY);
       })
     );
@@ -198,12 +206,14 @@
   async function handleSettingsSaved() {
     await savePos(SETTINGS_POS_KEY);
     showSettings = false;
+    await invoke("set_native_opaque", { opaque: false });
     if (appState === "idle") { appWindow.hide(); } else { await resizeTo(HUD_W, HUD_H, HUD_POS_KEY); }
   }
 
   async function handleSettingsClosed() {
     await savePos(SETTINGS_POS_KEY);
     showSettings = false;
+    await invoke("set_native_opaque", { opaque: false });
     if (appState === "idle") { appWindow.hide(); } else { await resizeTo(HUD_W, HUD_H, HUD_POS_KEY); }
   }
 
@@ -217,7 +227,7 @@
   }
 </script>
 
-<div class="container" class:panel-mode={showSettings || showOnboarding} style={windowOpacity < 1 ? `opacity:${windowOpacity}` : ''}>
+<div class="container">
   {#if showOnboarding}
     <OnboardingFlow on:done={handleOnboardingDone} />
   {:else if needsAccessibilityRestart}
@@ -241,7 +251,6 @@
   {:else if showSettings}
     <SettingsPanel
       bind:polishEnabled
-      bind:windowOpacity
       {audioDevices}
       bind:autostartEnabled
       bind:screenshotContextEnabled
@@ -262,10 +271,8 @@
     padding: 0;
   }
 
-  :global(html), :global(body) {
-    background: transparent;
-  }
   :global(body) {
+    background: transparent;
     font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
     -webkit-font-smoothing: antialiased;
     user-select: none;
@@ -277,10 +284,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-  }
-  .container.panel-mode {
-    overflow: hidden;
-    border-radius: 16px;
   }
 
   .ax-banner {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -85,6 +85,12 @@
       resizeTo(AX_W, AX_H);
     }
 
+    // Restore window opacity
+    const savedOpacity = localStorage.getItem("window-opacity");
+    if (savedOpacity) {
+      document.documentElement.style.opacity = savedOpacity;
+    }
+
     // Load settings data
     polishEnabled = await invoke<boolean>("get_polish_enabled").catch(() => true);
     audioDevices = await invoke<string[]>("list_audio_devices").catch(() => []);
@@ -96,6 +102,10 @@
       await listen<string>("state-change", (e) => {
         handleStateChange(e.payload);
         if (e.payload === "recording" || e.payload === "processing") {
+          if (showSettings) {
+            savePos(SETTINGS_POS_KEY);
+            showSettings = false;
+          }
           resizeTo(HUD_W, HUD_H, HUD_POS_KEY);
         } else if (e.payload === "idle" && !showSettings && !injectionFailed && !needsAccessibilityRestart) {
           setTimeout(() => appWindow.hide(), 800);
@@ -149,7 +159,13 @@
       })
     );
 
-    // 监听润色失败
+    // Sync when tray toggles polish
+    unlisten.push(
+      await listen<boolean>("polish-changed", (e) => {
+        polishEnabled = e.payload;
+      })
+    );
+
     unlisten.push(
       await listen("polish-failed", () => {
         polishFailed = true;
@@ -204,7 +220,7 @@
   }
 </script>
 
-<div class="container">
+<div class="container" class:panel-mode={showSettings || showOnboarding}>
   {#if showOnboarding}
     <OnboardingFlow on:done={handleOnboardingDone} />
   {:else if needsAccessibilityRestart}
@@ -261,6 +277,10 @@
     display: flex;
     align-items: center;
     justify-content: center;
+  }
+  .container.panel-mode {
+    overflow: hidden;
+    border-radius: 16px;
   }
 
   .ax-banner {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -6,7 +6,7 @@
   import { LogicalSize, LogicalPosition } from "@tauri-apps/api/dpi";
 
   const HUD_W = 200, HUD_H = 44;
-  const PANEL_W = 340, PANEL_H = 560;
+  const PANEL_W = 340, PANEL_H = 620;
   const AX_W = 320, AX_H = 160;
 
   const HUD_POS_KEY = "hud-window-pos";

--- a/src/lib/OnboardingFlow.svelte
+++ b/src/lib/OnboardingFlow.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher, onMount } from "svelte";
   import { invoke } from "@tauri-apps/api/core";
+  import { providers, getProvider, groupFields } from "./providers";
 
   const dispatch = createEventDispatcher();
 
@@ -8,46 +9,44 @@
   const totalSteps = isWindows ? 3 : 4;
 
   let step = 1;
-
-  let provider: "groq" | "vertex_ai" = "groq";
-  let apiKey = "";
-  let gcpProjectId = "";
-  let gcpLocation = "us-central1";
-  let vertexModel = "gemini-2.5-flash";
-  let adcAvailable = false;
+  let provider = providers[0]?.id ?? "groq";
+  let configValues: Record<string, string> = {};
+  let authStatus: boolean | null = null;
 
   let configSaving = false;
   let configSaved = false;
   let configError = "";
 
+  $: currentProvider = getProvider(provider);
+  $: fieldGroups = groupFields(currentProvider?.fields ?? []);
+
   onMount(async () => {
-    adcAvailable = await invoke<boolean>("check_vertex_auth").catch(() => false);
+    for (const p of providers) {
+      if (p.authCheck) {
+        const ok = await invoke<boolean>(p.authCheck, { provider: p.id }).catch(() => false);
+        if (p.id === provider) authStatus = ok;
+      }
+    }
   });
+
+  async function handleProviderSwitch(id: string) {
+    provider = id;
+    configValues = {};
+    configError = "";
+    const cp = getProvider(id);
+    if (cp?.authCheck) {
+      authStatus = await invoke<boolean>(cp.authCheck, { provider: id }).catch(() => false);
+    } else {
+      authStatus = null;
+    }
+  }
 
   async function saveConfig() {
     configSaving = true;
     configError = "";
     try {
       await invoke("save_provider", { provider });
-      if (provider === "groq") {
-        if (!apiKey.trim()) {
-          configError = "请输入 API Key";
-          configSaving = false;
-          return;
-        }
-        await invoke("save_api_key", { key: apiKey.trim() });
-      } else {
-        if (!gcpProjectId.trim()) {
-          configError = "请输入项目 ID";
-          configSaving = false;
-          return;
-        }
-        await invoke("save_vertex_config", {
-          projectId: gcpProjectId.trim(),
-          location: gcpLocation.trim() || "us-central1",
-          model: vertexModel,
-        });
-      }
+      await invoke("save_provider_config", { provider, configValues });
       configSaved = true;
       setTimeout(() => { step = isWindows ? totalSteps : 3; }, 500);
     } catch (e) {
@@ -73,7 +72,6 @@
 </script>
 
 <div class="onboarding">
-  <!-- Progress dots -->
   <div class="dots">
     {#each Array(totalSteps) as _, i}
       <div class="dot" class:active={i + 1 === step} class:done={i + 1 < step}></div>
@@ -93,7 +91,7 @@
         </svg>
       </div>
       <h1 class="app-name">Audio Input</h1>
-      <p class="app-desc">按下快捷键，说话，文字自动输入到任意应用。<br>支持 Groq Whisper 和 Google Vertex AI。</p>
+      <p class="app-desc">按下快捷键，说话，文字自动输入到任意应用。</p>
       <button class="primary-btn" on:click={next}>开始配置</button>
     </div>
 
@@ -103,81 +101,86 @@
       <div class="step-num">{step} / {totalSteps}</div>
       <h2>配置 AI 服务</h2>
 
-      <!-- Provider toggle -->
       <div class="provider-tabs">
-        <button
-          class="provider-tab"
-          class:active={provider === "groq"}
-          on:click={() => { provider = "groq"; configError = ""; }}
-        >
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="none">
-            <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-          <div class="tab-text">
-            <span class="tab-name">Groq</span>
-            <span class="tab-desc">免费 API Key</span>
-          </div>
-        </button>
-        <button
-          class="provider-tab"
-          class:active={provider === "vertex_ai"}
-          on:click={() => { provider = "vertex_ai"; configError = ""; }}
-        >
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="none">
-            <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/>
-            <polyline points="3.27 6.96 12 12.01 20.73 6.96" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-            <line x1="12" y1="22.08" x2="12" y2="12" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
-          </svg>
-          <div class="tab-text">
-            <span class="tab-name">Vertex AI</span>
-            <span class="tab-desc">Google Cloud</span>
-          </div>
-        </button>
+        {#each providers as p}
+          <button
+            class="provider-tab"
+            class:active={provider === p.id}
+            on:click={() => handleProviderSwitch(p.id)}
+          >
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none">{@html p.icon}</svg>
+            <div class="tab-text">
+              <span class="tab-name">{p.name}</span>
+              <span class="tab-desc">{p.tagline}</span>
+            </div>
+          </button>
+        {/each}
       </div>
 
-      <!-- Config form -->
-      {#if provider === "groq"}
-        <p class="desc">
-          前往 <a href="https://console.groq.com" target="_blank" rel="noopener">console.groq.com</a> 免费获取 API Key。
-        </p>
-        <input
-          type="password"
-          class="config-input"
-          placeholder="gsk_..."
-          bind:value={apiKey}
-          on:keydown={(e) => e.key === "Enter" && saveConfig()}
-          autocomplete="off"
-          spellcheck="false"
-        />
-      {:else}
-        <p class="desc">使用 gcloud 本地凭证连接 Vertex AI Gemini。</p>
-        <input
-          type="text"
-          class="config-input"
-          placeholder="GCP 项目 ID"
-          bind:value={gcpProjectId}
-          on:keydown={(e) => e.key === "Enter" && saveConfig()}
-          autocomplete="off"
-          spellcheck="false"
-        />
-        <div class="mini-row">
-          <input
-            type="text"
-            class="config-input mini mono"
-            placeholder="us-central1"
-            bind:value={gcpLocation}
-            autocomplete="off"
-            spellcheck="false"
-          />
-          <select class="config-select" bind:value={vertexModel}>
-            <option value="gemini-2.5-flash">2.5 Flash</option>
-            <option value="gemini-2.5-pro">2.5 Pro</option>
-            <option value="gemini-2.0-flash">2.0 Flash</option>
-          </select>
-        </div>
-        <div class="adc-status" class:ok={adcAvailable}>
-          <div class="adc-dot"></div>
-          <span>{adcAvailable ? "gcloud 凭证已就绪" : "运行 gcloud auth application-default login"}</span>
+      {#if currentProvider?.hint}
+        <p class="desc">{@html currentProvider.hint}</p>
+      {/if}
+
+      <!-- Dynamic config fields -->
+      {#each fieldGroups as group}
+        {#if group.length === 1}
+          {#if group[0].type === "select"}
+            <select class="config-select" bind:value={configValues[group[0].key]}>
+              {#each group[0].options ?? [] as opt}
+                <option value={opt.value}>{opt.label}</option>
+              {/each}
+            </select>
+          {:else if group[0].type === "password"}
+            <input
+              type="password"
+              class="config-input"
+              placeholder={group[0].placeholder ?? group[0].label}
+              bind:value={configValues[group[0].key]}
+              on:keydown={(e) => e.key === "Enter" && saveConfig()}
+              autocomplete="off"
+              spellcheck="false"
+            />
+          {:else}
+            <input
+              type="text"
+              class="config-input"
+              class:mono={group[0].mono}
+              placeholder={group[0].placeholder ?? group[0].label}
+              bind:value={configValues[group[0].key]}
+              on:keydown={(e) => e.key === "Enter" && saveConfig()}
+              autocomplete="off"
+              spellcheck="false"
+            />
+          {/if}
+        {:else}
+          <div class="mini-row">
+            {#each group as field}
+              {#if field.type === "select"}
+                <select class="config-select" bind:value={configValues[field.key]}>
+                  {#each field.options ?? [] as opt}
+                    <option value={opt.value}>{opt.label}</option>
+                  {/each}
+                </select>
+              {:else}
+                <input
+                  type="text"
+                  class="config-input mini"
+                  class:mono={field.mono}
+                  placeholder={field.placeholder ?? field.label}
+                  bind:value={configValues[field.key]}
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+              {/if}
+            {/each}
+          </div>
+        {/if}
+      {/each}
+
+      {#if authStatus !== null && currentProvider?.authOkText}
+        <div class="auth-badge" class:ok={authStatus}>
+          <div class="auth-dot"></div>
+          <span>{authStatus ? currentProvider.authOkText : currentProvider.authFailText}</span>
         </div>
       {/if}
 
@@ -192,15 +195,12 @@
       </div>
     </div>
 
-  <!-- Step 3: Accessibility -->
-  {:else if step === 3}
+  <!-- Step 3: Accessibility (macOS) -->
+  {:else if step === 3 && !isWindows}
     <div class="step">
       <div class="step-num">{step} / {totalSteps}</div>
       <h2>授权辅助功能</h2>
-      <p class="desc">
-        Audio Input 需要辅助功能权限才能将文字注入到其他应用。这是必要权限，不用于任何其他用途。
-      </p>
-
+      <p class="desc">Audio Input 需要辅助功能权限才能将文字注入到其他应用。</p>
       <div class="ax-illustration">
         <div class="path-step">
           <div class="path-icon">
@@ -213,26 +213,19 @@
           <span>系统设置</span>
         </div>
         <div class="path-arrow">›</div>
-        <div class="path-step">
-          <span>隐私与安全性</span>
-        </div>
+        <div class="path-step"><span>隐私与安全性</span></div>
         <div class="path-arrow">›</div>
-        <div class="path-step">
-          <span>辅助功能</span>
-        </div>
+        <div class="path-step"><span>辅助功能</span></div>
         <div class="path-arrow">›</div>
-        <div class="path-step highlight">
-          <span>+ Audio Input</span>
-        </div>
+        <div class="path-step highlight"><span>+ Audio Input</span></div>
       </div>
-
       <div class="btn-row">
         <button class="ghost-btn" on:click={next}>已完成</button>
         <button class="primary-btn" on:click={() => invoke("open_accessibility_prefs")}>打开系统设置</button>
       </div>
     </div>
 
-  <!-- Step 4 (or 3 on Windows): Done -->
+  <!-- Final step: Done -->
   {:else if step === totalSteps}
     <div class="step">
       <div class="done-check">
@@ -252,333 +245,59 @@
 </div>
 
 <style>
-  .onboarding {
-    width: 320px;
-    background: rgba(30, 30, 32, 0.92);
-    backdrop-filter: blur(20px) saturate(180%);
-    -webkit-backdrop-filter: blur(20px) saturate(180%);
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    border-radius: 20px;
-    box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5);
-    padding: 24px 24px 20px;
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-    font-family: -apple-system, "SF Pro Text", BlinkMacSystemFont, sans-serif;
-    -webkit-font-smoothing: antialiased;
-  }
-
-  /* Progress dots */
-  .dots {
-    display: flex;
-    gap: 6px;
-    justify-content: center;
-  }
-
-  .dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: rgba(255,255,255,0.15);
-    transition: background 0.2s, transform 0.2s;
-  }
-
-  .dot.active {
-    background: rgba(129, 140, 248, 0.9);
-    transform: scale(1.3);
-  }
-
-  .dot.done {
-    background: rgba(129, 140, 248, 0.4);
-  }
-
-  /* Step container */
-  .step {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 12px;
-    text-align: center;
-  }
-
-  .step-num {
-    font-size: 11px;
-    color: rgba(255,255,255,0.3);
-    letter-spacing: 0.05em;
-  }
-
-  .app-icon {
-    margin-top: 4px;
-  }
-
-  .app-name {
-    font-size: 22px;
-    font-weight: 700;
-    color: rgba(255,255,255,0.92);
-    letter-spacing: -0.02em;
-  }
-
-  h2 {
-    font-size: 17px;
-    font-weight: 600;
-    color: rgba(255,255,255,0.9);
-    letter-spacing: -0.01em;
-  }
-
-  .app-desc, .desc {
-    font-size: 13px;
-    color: rgba(255,255,255,0.5);
-    line-height: 1.6;
-    max-width: 260px;
-  }
-
-  .desc a {
-    color: rgba(129, 140, 248, 0.85);
-    text-decoration: none;
-  }
+  .onboarding { width:320px; background:rgba(30,30,32,0.92); backdrop-filter:blur(20px) saturate(180%); -webkit-backdrop-filter:blur(20px) saturate(180%); border:1px solid rgba(255,255,255,0.12); border-radius:20px; box-shadow:0 8px 40px rgba(0,0,0,0.5); padding:24px 24px 20px; display:flex; flex-direction:column; gap:16px; font-family:-apple-system,"SF Pro Text",BlinkMacSystemFont,sans-serif; -webkit-font-smoothing:antialiased; }
+  .dots { display:flex; gap:6px; justify-content:center; }
+  .dot { width:6px; height:6px; border-radius:50%; background:rgba(255,255,255,0.15); transition:background .2s,transform .2s; }
+  .dot.active { background:rgba(129,140,248,0.9); transform:scale(1.3); }
+  .dot.done { background:rgba(129,140,248,0.4); }
+  .step { display:flex; flex-direction:column; align-items:center; gap:12px; text-align:center; }
+  .step-num { font-size:11px; color:rgba(255,255,255,0.3); letter-spacing:.05em; }
+  .app-icon { margin-top:4px; }
+  .app-name { font-size:22px; font-weight:700; color:rgba(255,255,255,0.92); letter-spacing:-0.02em; }
+  h2 { font-size:17px; font-weight:600; color:rgba(255,255,255,0.9); letter-spacing:-0.01em; }
+  .app-desc,.desc { font-size:13px; color:rgba(255,255,255,0.5); line-height:1.6; max-width:260px; }
+  .desc :global(a) { color:rgba(129,140,248,0.85); text-decoration:none; }
+  .desc :global(code) { font-family:"SF Mono","Fira Code",monospace; font-size:10px; background:rgba(255,255,255,0.06); padding:1px 4px; border-radius:3px; color:rgba(255,255,255,0.5); }
 
   /* Provider tabs */
-  .provider-tabs {
-    display: flex;
-    gap: 8px;
-    width: 100%;
-  }
-
-  .provider-tab {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 10px 12px;
-    border-radius: 12px;
-    border: 1.5px solid rgba(255,255,255,0.08);
-    background: rgba(255,255,255,0.03);
-    color: rgba(255,255,255,0.4);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    font-family: -apple-system, "SF Pro Text", BlinkMacSystemFont, sans-serif;
-    text-align: left;
-  }
-
-  .provider-tab:hover {
-    border-color: rgba(255,255,255,0.15);
-    color: rgba(255,255,255,0.6);
-  }
-
-  .provider-tab.active {
-    border-color: rgba(129, 140, 248, 0.45);
-    background: rgba(99, 102, 241, 0.08);
-    color: rgba(165, 180, 252, 0.95);
-  }
-
-  .tab-text {
-    display: flex;
-    flex-direction: column;
-    gap: 1px;
-  }
-
-  .tab-name {
-    font-size: 13px;
-    font-weight: 600;
-  }
-
-  .tab-desc {
-    font-size: 10px;
-    opacity: 0.55;
-    font-weight: 400;
-  }
+  .provider-tabs { display:flex; gap:8px; width:100%; flex-wrap:wrap; }
+  .provider-tab { flex:1; min-width:0; display:flex; align-items:center; gap:8px; padding:10px 12px; border-radius:12px; border:1.5px solid rgba(255,255,255,0.08); background:rgba(255,255,255,0.03); color:rgba(255,255,255,0.4); cursor:pointer; transition:all .2s ease; font-family:-apple-system,"SF Pro Text",BlinkMacSystemFont,sans-serif; text-align:left; }
+  .provider-tab:hover { border-color:rgba(255,255,255,0.15); color:rgba(255,255,255,0.6); }
+  .provider-tab.active { border-color:rgba(129,140,248,0.45); background:rgba(99,102,241,0.08); color:rgba(165,180,252,0.95); }
+  .tab-text { display:flex; flex-direction:column; gap:1px; }
+  .tab-name { font-size:13px; font-weight:600; }
+  .tab-desc { font-size:10px; opacity:0.55; font-weight:400; }
 
   /* Config inputs */
-  .config-input {
-    width: 100%;
-    padding: 9px 12px;
-    border-radius: 10px;
-    border: 1px solid rgba(255,255,255,0.1);
-    background: rgba(255,255,255,0.05);
-    color: rgba(255,255,255,0.9);
-    font-size: 13px;
-    font-family: -apple-system, "SF Pro Text", BlinkMacSystemFont, sans-serif;
-    outline: none;
-    text-align: left;
-    transition: border-color 0.15s;
-  }
+  .config-input { width:100%; padding:9px 12px; border-radius:10px; border:1px solid rgba(255,255,255,0.1); background:rgba(255,255,255,0.05); color:rgba(255,255,255,0.9); font-size:13px; font-family:-apple-system,"SF Pro Text",BlinkMacSystemFont,sans-serif; outline:none; text-align:left; transition:border-color .15s; }
+  .config-input.mono { font-family:"SF Mono","Fira Code",monospace; font-size:12px; }
+  .config-input:focus { border-color:rgba(129,140,248,0.5); }
+  .config-input::placeholder { color:rgba(255,255,255,0.2); }
+  .mini-row { display:flex; gap:8px; width:100%; }
+  .config-input.mini { flex:1; min-width:0; }
+  .config-select { flex:1; min-width:0; padding:9px 8px; border-radius:10px; border:1px solid rgba(255,255,255,0.1); background:rgba(255,255,255,0.05); color:rgba(255,255,255,0.9); font-size:12px; font-family:-apple-system,"SF Pro Text",BlinkMacSystemFont,sans-serif; outline:none; cursor:pointer; appearance:auto; }
+  .err { font-size:12px; color:#f87171; align-self:flex-start; }
 
-  .config-input.mono {
-    font-family: "SF Mono", "Fira Code", monospace;
-    font-size: 12px;
-  }
+  /* Auth badge */
+  .auth-badge { display:flex; align-items:center; gap:6px; font-size:11px; color:rgba(248,113,113,0.75); width:100%; padding:6px 10px; border-radius:8px; background:rgba(248,113,113,0.05); border:1px solid rgba(248,113,113,0.1); text-align:left; }
+  .auth-badge.ok { color:rgba(134,239,172,0.8); background:rgba(74,222,128,0.05); border-color:rgba(74,222,128,0.12); }
+  .auth-dot { width:5px; height:5px; border-radius:50%; background:rgba(248,113,113,0.65); flex-shrink:0; }
+  .auth-badge.ok .auth-dot { background:rgba(74,222,128,0.65); }
 
-  .config-input:focus {
-    border-color: rgba(129, 140, 248, 0.5);
-  }
-
-  .config-input::placeholder {
-    color: rgba(255,255,255,0.2);
-  }
-
-  .mini-row {
-    display: flex;
-    gap: 8px;
-    width: 100%;
-  }
-
-  .config-input.mini {
-    flex: 1;
-    min-width: 0;
-  }
-
-  .config-select {
-    flex: 1;
-    min-width: 0;
-    padding: 9px 8px;
-    border-radius: 10px;
-    border: 1px solid rgba(255,255,255,0.1);
-    background: rgba(255,255,255,0.05);
-    color: rgba(255,255,255,0.9);
-    font-size: 12px;
-    font-family: -apple-system, "SF Pro Text", BlinkMacSystemFont, sans-serif;
-    outline: none;
-    cursor: pointer;
-    appearance: auto;
-  }
-
-  .err {
-    font-size: 12px;
-    color: #f87171;
-    align-self: flex-start;
-  }
-
-  /* ADC status */
-  .adc-status {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 11px;
-    color: rgba(248, 113, 113, 0.75);
-    width: 100%;
-    padding: 6px 10px;
-    border-radius: 8px;
-    background: rgba(248, 113, 113, 0.05);
-    border: 1px solid rgba(248, 113, 113, 0.1);
-    text-align: left;
-  }
-
-  .adc-status.ok {
-    color: rgba(134, 239, 172, 0.8);
-    background: rgba(74, 222, 128, 0.05);
-    border-color: rgba(74, 222, 128, 0.12);
-  }
-
-  .adc-dot {
-    width: 5px;
-    height: 5px;
-    border-radius: 50%;
-    background: rgba(248, 113, 113, 0.65);
-    flex-shrink: 0;
-  }
-
-  .adc-status.ok .adc-dot {
-    background: rgba(74, 222, 128, 0.65);
-  }
-
-  /* Accessibility illustration */
-  .ax-illustration {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    background: rgba(255,255,255,0.04);
-    border: 1px solid rgba(255,255,255,0.08);
-    border-radius: 10px;
-    padding: 10px 12px;
-    flex-wrap: wrap;
-    justify-content: center;
-    width: 100%;
-  }
-
-  .path-step {
-    display: flex;
-    align-items: center;
-    gap: 5px;
-    font-size: 11px;
-    color: rgba(255,255,255,0.55);
-  }
-
-  .path-step.highlight {
-    color: rgba(74, 222, 128, 0.85);
-    font-weight: 600;
-  }
-
-  .path-arrow {
-    font-size: 13px;
-    color: rgba(255,255,255,0.2);
-  }
-
-  .path-icon {
-    display: flex;
-    align-items: center;
-  }
-
-  /* Done state */
-  .done-check {
-    margin-top: 8px;
-  }
-
-  kbd {
-    display: inline-block;
-    padding: 2px 6px;
-    border-radius: 5px;
-    border: 1px solid rgba(255,255,255,0.15);
-    background: rgba(255,255,255,0.06);
-    font-family: -apple-system, "SF Pro Text", BlinkMacSystemFont, sans-serif;
-    font-size: 12px;
-    color: rgba(255,255,255,0.75);
-  }
+  /* Accessibility */
+  .ax-illustration { display:flex; align-items:center; gap:4px; background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.08); border-radius:10px; padding:10px 12px; flex-wrap:wrap; justify-content:center; width:100%; }
+  .path-step { display:flex; align-items:center; gap:5px; font-size:11px; color:rgba(255,255,255,0.55); }
+  .path-step.highlight { color:rgba(74,222,128,0.85); font-weight:600; }
+  .path-arrow { font-size:13px; color:rgba(255,255,255,0.2); }
+  .path-icon { display:flex; align-items:center; }
+  .done-check { margin-top:8px; }
+  kbd { display:inline-block; padding:2px 6px; border-radius:5px; border:1px solid rgba(255,255,255,0.15); background:rgba(255,255,255,0.06); font-family:-apple-system,"SF Pro Text",BlinkMacSystemFont,sans-serif; font-size:12px; color:rgba(255,255,255,0.75); }
 
   /* Buttons */
-  .btn-row {
-    display: flex;
-    gap: 10px;
-    width: 100%;
-    justify-content: center;
-    margin-top: 4px;
-  }
-
-  .primary-btn {
-    padding: 9px 22px;
-    border-radius: 10px;
-    border: none;
-    background: rgba(99, 102, 241, 0.85);
-    color: white;
-    font-size: 13px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: background 0.15s;
-    font-family: -apple-system, "SF Pro Text", BlinkMacSystemFont, sans-serif;
-  }
-
-  .primary-btn:hover:not(:disabled) {
-    background: rgba(99, 102, 241, 1);
-  }
-
-  .primary-btn:disabled {
-    opacity: 0.55;
-    cursor: not-allowed;
-  }
-
-  .ghost-btn {
-    padding: 9px 18px;
-    border-radius: 10px;
-    border: 1px solid rgba(255,255,255,0.12);
-    background: rgba(255,255,255,0.06);
-    color: rgba(255,255,255,0.55);
-    font-size: 13px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: background 0.15s;
-    font-family: -apple-system, "SF Pro Text", BlinkMacSystemFont, sans-serif;
-  }
-
-  .ghost-btn:hover {
-    background: rgba(255,255,255,0.1);
-  }
+  .btn-row { display:flex; gap:10px; width:100%; justify-content:center; margin-top:4px; }
+  .primary-btn { padding:9px 22px; border-radius:10px; border:none; background:rgba(99,102,241,0.85); color:white; font-size:13px; font-weight:600; cursor:pointer; transition:background .15s; font-family:-apple-system,"SF Pro Text",BlinkMacSystemFont,sans-serif; }
+  .primary-btn:hover:not(:disabled) { background:rgba(99,102,241,1); }
+  .primary-btn:disabled { opacity:0.55; cursor:not-allowed; }
+  .ghost-btn { padding:9px 18px; border-radius:10px; border:1px solid rgba(255,255,255,0.12); background:rgba(255,255,255,0.06); color:rgba(255,255,255,0.55); font-size:13px; font-weight:500; cursor:pointer; transition:background .15s; font-family:-apple-system,"SF Pro Text",BlinkMacSystemFont,sans-serif; }
+  .ghost-btn:hover { background:rgba(255,255,255,0.1); }
 </style>

--- a/src/lib/OnboardingFlow.svelte
+++ b/src/lib/OnboardingFlow.svelte
@@ -2,6 +2,7 @@
   import { createEventDispatcher, onMount } from "svelte";
   import { invoke } from "@tauri-apps/api/core";
   import { providers, getProvider, groupFields } from "./providers";
+  import { t, locale, type Locale } from "./i18n";
 
   const dispatch = createEventDispatcher();
 
@@ -69,6 +70,10 @@
   function next() {
     if (step < totalSteps) step++;
   }
+
+  function switchLocale(loc: Locale) {
+    $locale = loc;
+  }
 </script>
 
 <div class="onboarding">
@@ -81,6 +86,10 @@
   <!-- Step 1: Welcome -->
   {#if step === 1}
     <div class="step">
+      <div class="lang-pick">
+        <button class:active={$locale === 'en'} on:click={() => switchLocale('en')}>EN</button>
+        <button class:active={$locale === 'zh'} on:click={() => switchLocale('zh')}>中文</button>
+      </div>
       <div class="app-icon">
         <svg width="44" height="44" viewBox="0 0 48 48" fill="none">
           <rect width="48" height="48" rx="12" fill="rgba(99,102,241,0.18)"/>
@@ -90,16 +99,16 @@
           <line x1="18" y1="42" x2="30" y2="42" stroke="rgba(129,140,248,0.9)" stroke-width="3" stroke-linecap="round"/>
         </svg>
       </div>
-      <h1 class="app-name">Audio Input</h1>
-      <p class="app-desc">按下快捷键，说话，文字自动输入到任意应用。</p>
-      <button class="primary-btn" on:click={next}>开始配置</button>
+      <h1 class="app-name">{$t('app.name')}</h1>
+      <p class="app-desc">{$t('app.desc')}</p>
+      <button class="primary-btn" on:click={next}>{$t('onboarding.start')}</button>
     </div>
 
   <!-- Step 2: Provider + Config -->
   {:else if step === 2}
     <div class="step">
       <div class="step-num">{step} / {totalSteps}</div>
-      <h2>配置 AI 服务</h2>
+      <h2>{$t('onboarding.configure')}</h2>
 
       <div class="provider-tabs">
         {#each providers as p}
@@ -111,14 +120,14 @@
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none">{@html p.icon}</svg>
             <div class="tab-text">
               <span class="tab-name">{p.name}</span>
-              <span class="tab-desc">{p.tagline}</span>
+              <span class="tab-desc">{p.tagline[$locale]}</span>
             </div>
           </button>
         {/each}
       </div>
 
       {#if currentProvider?.hint}
-        <p class="desc">{@html currentProvider.hint}</p>
+        <p class="desc">{@html currentProvider.hint[$locale]}</p>
       {/if}
 
       <!-- Dynamic config fields -->
@@ -134,7 +143,7 @@
             <input
               type="password"
               class="config-input"
-              placeholder={group[0].placeholder ?? group[0].label}
+              placeholder={group[0].placeholder ?? group[0].label[$locale]}
               bind:value={configValues[group[0].key]}
               on:keydown={(e) => e.key === "Enter" && saveConfig()}
               autocomplete="off"
@@ -145,7 +154,7 @@
               type="text"
               class="config-input"
               class:mono={group[0].mono}
-              placeholder={group[0].placeholder ?? group[0].label}
+              placeholder={group[0].placeholder ?? group[0].label[$locale]}
               bind:value={configValues[group[0].key]}
               on:keydown={(e) => e.key === "Enter" && saveConfig()}
               autocomplete="off"
@@ -166,7 +175,7 @@
                   type="text"
                   class="config-input mini"
                   class:mono={field.mono}
-                  placeholder={field.placeholder ?? field.label}
+                  placeholder={field.placeholder ?? field.label[$locale]}
                   bind:value={configValues[field.key]}
                   autocomplete="off"
                   spellcheck="false"
@@ -180,7 +189,7 @@
       {#if authStatus !== null && currentProvider?.authOkText}
         <div class="auth-badge" class:ok={authStatus}>
           <div class="auth-dot"></div>
-          <span>{authStatus ? currentProvider.authOkText : currentProvider.authFailText}</span>
+          <span>{authStatus ? currentProvider.authOkText[$locale] : (currentProvider.authFailText ?? currentProvider.authOkText)[$locale]}</span>
         </div>
       {/if}
 
@@ -188,9 +197,9 @@
         <div class="err">{configError}</div>
       {/if}
       <div class="btn-row">
-        <button class="ghost-btn" on:click={skipConfig}>跳过</button>
+        <button class="ghost-btn" on:click={skipConfig}>{$t('onboarding.skip')}</button>
         <button class="primary-btn" on:click={saveConfig} disabled={configSaving}>
-          {#if configSaved}已保存{:else if configSaving}保存中...{:else}保存并继续{/if}
+          {#if configSaved}{$t('onboarding.saved')}{:else if configSaving}{$t('settings.saving')}{:else}{$t('onboarding.save_continue')}{/if}
         </button>
       </div>
     </div>
@@ -199,8 +208,8 @@
   {:else if step === 3 && !isWindows}
     <div class="step">
       <div class="step-num">{step} / {totalSteps}</div>
-      <h2>授权辅助功能</h2>
-      <p class="desc">Audio Input 需要辅助功能权限才能将文字注入到其他应用。</p>
+      <h2>{$t('onboarding.ax_title')}</h2>
+      <p class="desc">{$t('onboarding.ax_desc')}</p>
       <div class="ax-illustration">
         <div class="path-step">
           <div class="path-icon">
@@ -210,18 +219,18 @@
               <line x1="12" y1="12" x2="12" y2="18" stroke="rgba(129,140,248,0.8)" stroke-width="1.8" stroke-linecap="round"/>
             </svg>
           </div>
-          <span>系统设置</span>
+          <span>{$t('onboarding.ax_path1')}</span>
         </div>
         <div class="path-arrow">›</div>
-        <div class="path-step"><span>隐私与安全性</span></div>
+        <div class="path-step"><span>{$t('onboarding.ax_path2')}</span></div>
         <div class="path-arrow">›</div>
-        <div class="path-step"><span>辅助功能</span></div>
+        <div class="path-step"><span>{$t('onboarding.ax_path3')}</span></div>
         <div class="path-arrow">›</div>
-        <div class="path-step highlight"><span>+ Audio Input</span></div>
+        <div class="path-step highlight"><span>{$t('onboarding.ax_path4')}</span></div>
       </div>
       <div class="btn-row">
-        <button class="ghost-btn" on:click={next}>已完成</button>
-        <button class="primary-btn" on:click={() => invoke("open_accessibility_prefs")}>打开系统设置</button>
+        <button class="ghost-btn" on:click={next}>{$t('onboarding.ax_done')}</button>
+        <button class="primary-btn" on:click={() => invoke("open_accessibility_prefs")}>{$t('onboarding.ax_open')}</button>
       </div>
     </div>
 
@@ -234,12 +243,11 @@
           <path d="M8 14l4 4 8-8" stroke="rgba(74,222,128,0.9)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
       </div>
-      <h2>准备就绪！</h2>
+      <h2>{$t('onboarding.ready')}</h2>
       <p class="desc">
-        按下 <kbd>{isWindows ? "Ctrl+Shift+Space" : "⌘⇧Space"}</kbd> 开始录音，松开自动转文字并输入到光标位置。
-        <br>点击{isWindows ? "系统托盘" : "菜单栏"}图标可打开设置。
+        {$t(isWindows ? 'onboarding.ready_win' : 'onboarding.ready_mac', isWindows ? 'Ctrl+Shift+Space' : '⌘⇧Space')}
       </p>
-      <button class="primary-btn" on:click={finishOnboarding}>开始使用</button>
+      <button class="primary-btn" on:click={finishOnboarding}>{$t('onboarding.finish')}</button>
     </div>
   {/if}
 </div>
@@ -255,9 +263,15 @@
   .app-icon { margin-top:4px; }
   .app-name { font-size:22px; font-weight:700; color:rgba(255,255,255,0.92); letter-spacing:-0.02em; }
   h2 { font-size:17px; font-weight:600; color:rgba(255,255,255,0.9); letter-spacing:-0.01em; }
-  .app-desc,.desc { font-size:13px; color:rgba(255,255,255,0.5); line-height:1.6; max-width:260px; }
+  .app-desc,.desc { font-size:13px; color:rgba(255,255,255,0.5); line-height:1.6; max-width:260px; white-space:pre-line; }
   .desc :global(a) { color:rgba(129,140,248,0.85); text-decoration:none; }
   .desc :global(code) { font-family:"SF Mono","Fira Code",monospace; font-size:10px; background:rgba(255,255,255,0.06); padding:1px 4px; border-radius:3px; color:rgba(255,255,255,0.5); }
+
+  /* Language picker on welcome step */
+  .lang-pick { display:flex; gap:0; background:rgba(255,255,255,0.04); border-radius:8px; padding:2px; border:1px solid rgba(255,255,255,0.06); }
+  .lang-pick button { padding:4px 14px; border:none; border-radius:6px; background:transparent; color:rgba(255,255,255,0.35); font-size:12px; font-weight:500; cursor:pointer; transition:all .2s; font-family:-apple-system,"SF Pro Text",BlinkMacSystemFont,sans-serif; }
+  .lang-pick button:hover { color:rgba(255,255,255,0.55); }
+  .lang-pick button.active { background:rgba(99,102,241,0.2); color:rgba(165,180,252,0.95); }
 
   /* Provider tabs */
   .provider-tabs { display:flex; gap:8px; width:100%; flex-wrap:wrap; }
@@ -291,7 +305,6 @@
   .path-arrow { font-size:13px; color:rgba(255,255,255,0.2); }
   .path-icon { display:flex; align-items:center; }
   .done-check { margin-top:8px; }
-  kbd { display:inline-block; padding:2px 6px; border-radius:5px; border:1px solid rgba(255,255,255,0.15); background:rgba(255,255,255,0.06); font-family:-apple-system,"SF Pro Text",BlinkMacSystemFont,sans-serif; font-size:12px; color:rgba(255,255,255,0.75); }
 
   /* Buttons */
   .btn-row { display:flex; gap:10px; width:100%; justify-content:center; margin-top:4px; }

--- a/src/lib/OnboardingFlow.svelte
+++ b/src/lib/OnboardingFlow.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, onMount } from "svelte";
   import { invoke } from "@tauri-apps/api/core";
 
   const dispatch = createEventDispatcher();
@@ -9,27 +9,57 @@
 
   let step = 1;
 
+  let provider: "groq" | "vertex_ai" = "groq";
   let apiKey = "";
-  let apiKeySaving = false;
-  let apiKeySaved = false;
-  let apiKeyError = "";
+  let gcpProjectId = "";
+  let gcpLocation = "us-central1";
+  let vertexModel = "gemini-2.5-flash";
+  let adcAvailable = false;
 
-  async function saveApiKey() {
-    if (!apiKey.trim()) {
-      apiKeyError = "请输入 API Key";
-      return;
-    }
-    apiKeySaving = true;
-    apiKeyError = "";
+  let configSaving = false;
+  let configSaved = false;
+  let configError = "";
+
+  onMount(async () => {
+    adcAvailable = await invoke<boolean>("check_vertex_auth").catch(() => false);
+  });
+
+  async function saveConfig() {
+    configSaving = true;
+    configError = "";
     try {
-      await invoke("save_api_key", { key: apiKey.trim() });
-      apiKeySaved = true;
-      setTimeout(() => { step = isWindows ? 4 : 3; }, 600);
+      await invoke("save_provider", { provider });
+      if (provider === "groq") {
+        if (!apiKey.trim()) {
+          configError = "请输入 API Key";
+          configSaving = false;
+          return;
+        }
+        await invoke("save_api_key", { key: apiKey.trim() });
+      } else {
+        if (!gcpProjectId.trim()) {
+          configError = "请输入项目 ID";
+          configSaving = false;
+          return;
+        }
+        await invoke("save_vertex_config", {
+          projectId: gcpProjectId.trim(),
+          location: gcpLocation.trim() || "us-central1",
+          model: vertexModel,
+        });
+      }
+      configSaved = true;
+      setTimeout(() => { step = isWindows ? totalSteps : 3; }, 500);
     } catch (e) {
-      apiKeyError = String(e);
+      configError = String(e);
     } finally {
-      apiKeySaving = false;
+      configSaving = false;
     }
+  }
+
+  async function skipConfig() {
+    await invoke("save_provider", { provider });
+    step = isWindows ? totalSteps : 3;
   }
 
   async function finishOnboarding() {
@@ -63,34 +93,101 @@
         </svg>
       </div>
       <h1 class="app-name">Audio Input</h1>
-      <p class="app-desc">按下快捷键，说话，文字自动输入到任意应用。<br>基于 Groq Whisper 的极速语音转文字。</p>
+      <p class="app-desc">按下快捷键，说话，文字自动输入到任意应用。<br>支持 Groq Whisper 和 Google Vertex AI。</p>
       <button class="primary-btn" on:click={next}>开始配置</button>
     </div>
 
-  <!-- Step 2: API Key -->
+  <!-- Step 2: Provider + Config -->
   {:else if step === 2}
     <div class="step">
-      <div class="step-num">2 / 4</div>
-      <h2>配置 Groq API Key</h2>
-      <p class="desc">
-        前往 <a href="https://console.groq.com" target="_blank" rel="noopener">console.groq.com</a> 免费注册并获取 API Key（免费额度足够日常使用）。
-      </p>
-      <input
-        type="password"
-        class="api-input"
-        placeholder="gsk_..."
-        bind:value={apiKey}
-        on:keydown={(e) => e.key === "Enter" && saveApiKey()}
-        autocomplete="off"
-        spellcheck="false"
-      />
-      {#if apiKeyError}
-        <div class="err">{apiKeyError}</div>
+      <div class="step-num">{step} / {totalSteps}</div>
+      <h2>配置 AI 服务</h2>
+
+      <!-- Provider toggle -->
+      <div class="provider-tabs">
+        <button
+          class="provider-tab"
+          class:active={provider === "groq"}
+          on:click={() => { provider = "groq"; configError = ""; }}
+        >
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none">
+            <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          <div class="tab-text">
+            <span class="tab-name">Groq</span>
+            <span class="tab-desc">免费 API Key</span>
+          </div>
+        </button>
+        <button
+          class="provider-tab"
+          class:active={provider === "vertex_ai"}
+          on:click={() => { provider = "vertex_ai"; configError = ""; }}
+        >
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none">
+            <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/>
+            <polyline points="3.27 6.96 12 12.01 20.73 6.96" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+            <line x1="12" y1="22.08" x2="12" y2="12" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+          </svg>
+          <div class="tab-text">
+            <span class="tab-name">Vertex AI</span>
+            <span class="tab-desc">Google Cloud</span>
+          </div>
+        </button>
+      </div>
+
+      <!-- Config form -->
+      {#if provider === "groq"}
+        <p class="desc">
+          前往 <a href="https://console.groq.com" target="_blank" rel="noopener">console.groq.com</a> 免费获取 API Key。
+        </p>
+        <input
+          type="password"
+          class="config-input"
+          placeholder="gsk_..."
+          bind:value={apiKey}
+          on:keydown={(e) => e.key === "Enter" && saveConfig()}
+          autocomplete="off"
+          spellcheck="false"
+        />
+      {:else}
+        <p class="desc">使用 gcloud 本地凭证连接 Vertex AI Gemini。</p>
+        <input
+          type="text"
+          class="config-input"
+          placeholder="GCP 项目 ID"
+          bind:value={gcpProjectId}
+          on:keydown={(e) => e.key === "Enter" && saveConfig()}
+          autocomplete="off"
+          spellcheck="false"
+        />
+        <div class="mini-row">
+          <input
+            type="text"
+            class="config-input mini mono"
+            placeholder="us-central1"
+            bind:value={gcpLocation}
+            autocomplete="off"
+            spellcheck="false"
+          />
+          <select class="config-select" bind:value={vertexModel}>
+            <option value="gemini-2.5-flash">2.5 Flash</option>
+            <option value="gemini-2.5-pro">2.5 Pro</option>
+            <option value="gemini-2.0-flash">2.0 Flash</option>
+          </select>
+        </div>
+        <div class="adc-status" class:ok={adcAvailable}>
+          <div class="adc-dot"></div>
+          <span>{adcAvailable ? "gcloud 凭证已就绪" : "运行 gcloud auth application-default login"}</span>
+        </div>
+      {/if}
+
+      {#if configError}
+        <div class="err">{configError}</div>
       {/if}
       <div class="btn-row">
-        <button class="ghost-btn" on:click={() => { step = isWindows ? 4 : 3; }}>跳过</button>
-        <button class="primary-btn" on:click={saveApiKey} disabled={apiKeySaving}>
-          {#if apiKeySaved}已保存{:else if apiKeySaving}保存中...{:else}保存并继续{/if}
+        <button class="ghost-btn" on:click={skipConfig}>跳过</button>
+        <button class="primary-btn" on:click={saveConfig} disabled={configSaving}>
+          {#if configSaved}已保存{:else if configSaving}保存中...{:else}保存并继续{/if}
         </button>
       </div>
     </div>
@@ -98,13 +195,12 @@
   <!-- Step 3: Accessibility -->
   {:else if step === 3}
     <div class="step">
-      <div class="step-num">3 / 4</div>
+      <div class="step-num">{step} / {totalSteps}</div>
       <h2>授权辅助功能</h2>
       <p class="desc">
         Audio Input 需要辅助功能权限才能将文字注入到其他应用。这是必要权限，不用于任何其他用途。
       </p>
 
-      <!-- CSS illustration of system settings path -->
       <div class="ax-illustration">
         <div class="path-step">
           <div class="path-icon">
@@ -136,8 +232,8 @@
       </div>
     </div>
 
-  <!-- Step 4: Done -->
-  {:else if step === 4}
+  <!-- Step 4 (or 3 on Windows): Done -->
+  {:else if step === totalSteps}
     <div class="step">
       <div class="done-check">
         <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
@@ -241,7 +337,59 @@
     text-decoration: none;
   }
 
-  .api-input {
+  /* Provider tabs */
+  .provider-tabs {
+    display: flex;
+    gap: 8px;
+    width: 100%;
+  }
+
+  .provider-tab {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 12px;
+    border-radius: 12px;
+    border: 1.5px solid rgba(255,255,255,0.08);
+    background: rgba(255,255,255,0.03);
+    color: rgba(255,255,255,0.4);
+    cursor: pointer;
+    transition: all 0.2s ease;
+    font-family: -apple-system, "SF Pro Text", BlinkMacSystemFont, sans-serif;
+    text-align: left;
+  }
+
+  .provider-tab:hover {
+    border-color: rgba(255,255,255,0.15);
+    color: rgba(255,255,255,0.6);
+  }
+
+  .provider-tab.active {
+    border-color: rgba(129, 140, 248, 0.45);
+    background: rgba(99, 102, 241, 0.08);
+    color: rgba(165, 180, 252, 0.95);
+  }
+
+  .tab-text {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+
+  .tab-name {
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  .tab-desc {
+    font-size: 10px;
+    opacity: 0.55;
+    font-weight: 400;
+  }
+
+  /* Config inputs */
+  .config-input {
     width: 100%;
     padding: 9px 12px;
     border-radius: 10px;
@@ -249,24 +397,88 @@
     background: rgba(255,255,255,0.05);
     color: rgba(255,255,255,0.9);
     font-size: 13px;
-    font-family: "SF Mono", "Fira Code", monospace;
+    font-family: -apple-system, "SF Pro Text", BlinkMacSystemFont, sans-serif;
     outline: none;
     text-align: left;
     transition: border-color 0.15s;
   }
 
-  .api-input:focus {
+  .config-input.mono {
+    font-family: "SF Mono", "Fira Code", monospace;
+    font-size: 12px;
+  }
+
+  .config-input:focus {
     border-color: rgba(129, 140, 248, 0.5);
   }
 
-  .api-input::placeholder {
+  .config-input::placeholder {
     color: rgba(255,255,255,0.2);
+  }
+
+  .mini-row {
+    display: flex;
+    gap: 8px;
+    width: 100%;
+  }
+
+  .config-input.mini {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .config-select {
+    flex: 1;
+    min-width: 0;
+    padding: 9px 8px;
+    border-radius: 10px;
+    border: 1px solid rgba(255,255,255,0.1);
+    background: rgba(255,255,255,0.05);
+    color: rgba(255,255,255,0.9);
+    font-size: 12px;
+    font-family: -apple-system, "SF Pro Text", BlinkMacSystemFont, sans-serif;
+    outline: none;
+    cursor: pointer;
+    appearance: auto;
   }
 
   .err {
     font-size: 12px;
     color: #f87171;
     align-self: flex-start;
+  }
+
+  /* ADC status */
+  .adc-status {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+    color: rgba(248, 113, 113, 0.75);
+    width: 100%;
+    padding: 6px 10px;
+    border-radius: 8px;
+    background: rgba(248, 113, 113, 0.05);
+    border: 1px solid rgba(248, 113, 113, 0.1);
+    text-align: left;
+  }
+
+  .adc-status.ok {
+    color: rgba(134, 239, 172, 0.8);
+    background: rgba(74, 222, 128, 0.05);
+    border-color: rgba(74, 222, 128, 0.12);
+  }
+
+  .adc-dot {
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: rgba(248, 113, 113, 0.65);
+    flex-shrink: 0;
+  }
+
+  .adc-status.ok .adc-dot {
+    background: rgba(74, 222, 128, 0.65);
   }
 
   /* Accessibility illustration */

--- a/src/lib/RecordingIndicator.svelte
+++ b/src/lib/RecordingIndicator.svelte
@@ -22,10 +22,10 @@
     seconds = 0;
   }
 
-  let _prev = state;
-  $: if (state !== _prev) {
-    _prev = state;
-    if (state === "recording") startTimer(); else stopTimer();
+  $: if (state === "recording") {
+    if (timer === null) startTimer();
+  } else {
+    if (timer !== null) stopTimer();
   }
 
   function fmt(s: number) {

--- a/src/lib/RecordingIndicator.svelte
+++ b/src/lib/RecordingIndicator.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { getCurrentWindow } from "@tauri-apps/api/window";
+  import { t } from "./i18n";
 
   export let state: "idle" | "recording" | "processing" | "error" = "idle";
   export let errorMsg = "";
@@ -51,22 +52,22 @@
 
   {:else if state === "processing"}
     <div class="spinner"></div>
-    <span class="label blue">Transcribing…</span>
+    <span class="label blue">{$t('hud.transcribing')}</span>
 
   {:else if state === "error"}
     <div class="err-dot"></div>
-    <span class="label red">{errorMsg || "Error"}</span>
+    <span class="label red">{errorMsg || $t('hud.error')}</span>
 
   {:else if injectionFailed && lastTranscription}
     <svg class="clip-icon" width="13" height="13" viewBox="0 0 24 24" fill="none">
       <rect x="8" y="2" width="8" height="4" rx="1" stroke="rgba(255,200,80,0.9)" stroke-width="1.8"/>
       <path d="M6 4H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2h-1" stroke="rgba(255,200,80,0.9)" stroke-width="1.8" stroke-linecap="round"/>
     </svg>
-    <span class="label amber">Copied — ⌘V to paste</span>
+    <span class="label amber">{$t('hud.copied')}</span>
 
   {:else if polishFailed}
     <div class="err-dot"></div>
-    <span class="label amber">Polish failed — original used</span>
+    <span class="label amber">{$t('hud.polish_failed')}</span>
   {/if}
 
 </div>

--- a/src/lib/SettingsPanel.svelte
+++ b/src/lib/SettingsPanel.svelte
@@ -20,7 +20,6 @@
 
   let preferredDevice: string | null = null;
   let shortcut = "Meta+Shift+Space";
-  export let windowOpacity: number = 1.0;
   let saving = false;
   let saved = false;
   let error = "";
@@ -64,11 +63,6 @@
     } finally {
       saving = false;
     }
-  }
-
-  function handleOpacityChange(e: Event) {
-    windowOpacity = parseFloat((e.target as HTMLInputElement).value);
-    localStorage.setItem("window-opacity", String(windowOpacity));
   }
 
   async function handlePolishToggle() {
@@ -315,16 +309,6 @@
       </button>
     </div>
 
-    <div class="divider"></div>
-
-    <!-- Opacity -->
-    <div class="section">
-      <div class="row-label-block">
-        <span class="section-label">{$t('settings.opacity')}</span>
-        <span class="row-desc">{Math.round(windowOpacity * 100)}%</span>
-      </div>
-      <input type="range" min="0.2" max="1" step="0.05" value={windowOpacity} on:input={handleOpacityChange} class="opacity-slider" />
-    </div>
   </div>
 
   {#if error}<div class="error-banner">{error}</div>{/if}
@@ -333,12 +317,13 @@
 
 <style>
   .settings-panel {
-    width: 100%;
-    height: 100%;
-    background: #1e1e20;
+    width: 320px;
+    background: rgba(30,30,32,0.92);
+    backdrop-filter: blur(20px) saturate(180%);
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+    border-radius: 16px;
+    box-shadow: 0 8px 40px rgba(0,0,0,0.5);
     overflow: hidden;
-    display: flex;
-    flex-direction: column;
     font-family: -apple-system,"SF Pro Text",BlinkMacSystemFont,sans-serif;
     -webkit-font-smoothing: antialiased;
   }
@@ -353,7 +338,7 @@
   @keyframes spin { to { transform:rotate(360deg); } }
   .close-btn { background:rgba(255,255,255,0.08); border:none; border-radius:50%; width:22px; height:22px; display:flex; align-items:center; justify-content:center; cursor:pointer; transition:background .15s; padding:0; }
   .close-btn:hover { background:rgba(255,255,255,0.15); }
-  .sections { padding:4px 0; overflow-y:auto; flex:1; min-height:0; }
+  .sections { padding:4px 0; overflow-y:auto; max-height:calc(100vh - 56px); }
   .section { padding:11px 16px; display:flex; flex-direction:column; gap:7px; }
   .section.row-section { flex-direction:row; align-items:center; justify-content:space-between; }
   .section-label { font-size:13px; font-weight:500; color:rgba(255,255,255,0.8); }
@@ -411,5 +396,4 @@
   .conflict-banner { padding:6px 10px; border-radius:8px; background:rgba(251,191,36,0.08); border:1px solid rgba(251,191,36,0.2); font-size:11px; color:rgba(251,191,36,0.85); line-height:1.5; }
   .error-banner { margin:0 16px 12px; padding:7px 10px; border-radius:8px; background:rgba(248,113,113,0.12); border:1px solid rgba(248,113,113,0.25); font-size:12px; color:#f87171; }
   .saved-banner { margin:0 16px 12px; padding:7px 10px; border-radius:8px; background:rgba(74,222,128,0.1); border:1px solid rgba(74,222,128,0.25); font-size:12px; color:rgba(134,239,172,0.9); text-align:center; }
-  .opacity-slider { width:100%; accent-color:rgba(99,102,241,0.85); cursor:pointer; }
 </style>

--- a/src/lib/SettingsPanel.svelte
+++ b/src/lib/SettingsPanel.svelte
@@ -20,10 +20,10 @@
 
   let preferredDevice: string | null = null;
   let shortcut = "Meta+Shift+Space";
+  export let windowOpacity: number = 1.0;
   let saving = false;
   let saved = false;
   let error = "";
-  let opacity = 1.0;
 
   $: currentProvider = getProvider(provider);
   $: fieldGroups = groupFields(currentProvider?.fields ?? []);
@@ -33,11 +33,6 @@
     await loadProviderConfig();
     shortcut = await invoke<string>("get_shortcut");
     preferredDevice = await invoke<string | null>("get_preferred_device").catch(() => null);
-    const savedOpacity = localStorage.getItem("window-opacity");
-    if (savedOpacity) {
-      opacity = parseFloat(savedOpacity);
-      document.documentElement.style.opacity = String(opacity);
-    }
   });
 
   async function loadProviderConfig() {
@@ -71,10 +66,9 @@
     }
   }
 
-  async function handleOpacityChange(e: Event) {
-    opacity = parseFloat((e.target as HTMLInputElement).value);
-    localStorage.setItem("window-opacity", String(opacity));
-    document.documentElement.style.opacity = String(opacity);
+  function handleOpacityChange(e: Event) {
+    windowOpacity = parseFloat((e.target as HTMLInputElement).value);
+    localStorage.setItem("window-opacity", String(windowOpacity));
   }
 
   async function handlePolishToggle() {
@@ -327,9 +321,9 @@
     <div class="section">
       <div class="row-label-block">
         <span class="section-label">{$t('settings.opacity')}</span>
-        <span class="row-desc">{Math.round(opacity * 100)}%</span>
+        <span class="row-desc">{Math.round(windowOpacity * 100)}%</span>
       </div>
-      <input type="range" min="0.2" max="1" step="0.05" value={opacity} on:input={handleOpacityChange} class="opacity-slider" />
+      <input type="range" min="0.2" max="1" step="0.05" value={windowOpacity} on:input={handleOpacityChange} class="opacity-slider" />
     </div>
   </div>
 
@@ -339,13 +333,12 @@
 
 <style>
   .settings-panel {
-    width: 320px;
-    background: rgba(30,30,32,0.92);
-    backdrop-filter: blur(20px) saturate(180%);
-    -webkit-backdrop-filter: blur(20px) saturate(180%);
-    border-radius: 16px;
-    box-shadow: 0 8px 40px rgba(0,0,0,0.5);
+    width: 100%;
+    height: 100%;
+    background: #1e1e20;
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
     font-family: -apple-system,"SF Pro Text",BlinkMacSystemFont,sans-serif;
     -webkit-font-smoothing: antialiased;
   }
@@ -360,7 +353,7 @@
   @keyframes spin { to { transform:rotate(360deg); } }
   .close-btn { background:rgba(255,255,255,0.08); border:none; border-radius:50%; width:22px; height:22px; display:flex; align-items:center; justify-content:center; cursor:pointer; transition:background .15s; padding:0; }
   .close-btn:hover { background:rgba(255,255,255,0.15); }
-  .sections { padding:4px 0; overflow-y:auto; max-height:calc(100vh - 56px); }
+  .sections { padding:4px 0; overflow-y:auto; flex:1; min-height:0; }
   .section { padding:11px 16px; display:flex; flex-direction:column; gap:7px; }
   .section.row-section { flex-direction:row; align-items:center; justify-content:space-between; }
   .section-label { font-size:13px; font-weight:500; color:rgba(255,255,255,0.8); }

--- a/src/lib/SettingsPanel.svelte
+++ b/src/lib/SettingsPanel.svelte
@@ -2,8 +2,7 @@
   import { createEventDispatcher, onMount } from "svelte";
   import { invoke } from "@tauri-apps/api/core";
   import { getCurrentWindow } from "@tauri-apps/api/window";
-
-  const isWindows = navigator.userAgent.includes("Windows");
+  import { providers, getProvider, groupFields, type ProviderDef, type ProviderField } from "./providers";
 
   const dispatch = createEventDispatcher();
 
@@ -12,13 +11,11 @@
   export let autostartEnabled: boolean = false;
   export let screenshotContextEnabled: boolean = false;
   export let appState: string = "idle";
+  export let shortcutConflict: string = "";
 
-  let provider: "groq" | "vertex_ai" = "groq";
-  let apiKey = "";
-  let gcpProjectId = "";
-  let gcpLocation = "us-central1";
-  let vertexModel = "gemini-2.5-flash";
-  let adcAvailable = false;
+  let provider = "groq";
+  let configValues: Record<string, string> = {};
+  let authStatus: boolean | null = null;
 
   let preferredDevice: string | null = null;
   let shortcut = "Meta+Shift+Space";
@@ -27,78 +24,56 @@
   let error = "";
   let opacity = 1.0;
 
-  const vertexModels = [
-    { value: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
-    { value: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
-    { value: "gemini-2.0-flash", label: "Gemini 2.0 Flash" },
-  ];
+  $: currentProvider = getProvider(provider);
+  $: fieldGroups = groupFields(currentProvider?.fields ?? []);
 
   onMount(async () => {
-    provider = (await invoke<string>("get_provider")) as typeof provider;
-    apiKey = await invoke<string>("get_saved_api_key");
+    provider = await invoke<string>("get_provider");
+    await loadProviderConfig();
     shortcut = await invoke<string>("get_shortcut");
-    const cfg = await invoke<string | null>("get_preferred_device").catch(() => null);
-    preferredDevice = cfg;
+    preferredDevice = await invoke<string | null>("get_preferred_device").catch(() => null);
     const savedOpacity = localStorage.getItem("window-opacity");
     if (savedOpacity) {
       opacity = parseFloat(savedOpacity);
       await getCurrentWindow().setOpacity(opacity);
     }
-    const vc = await invoke<{ project_id: string; location: string; model: string }>("get_vertex_config");
-    gcpProjectId = vc.project_id;
-    gcpLocation = vc.location || "us-central1";
-    vertexModel = vc.model || "gemini-2.5-flash";
-    adcAvailable = await invoke<boolean>("check_vertex_auth").catch(() => false);
   });
+
+  async function loadProviderConfig() {
+    const raw = await invoke<Record<string, string>>("get_provider_config", { provider });
+    configValues = raw ?? {};
+    const cp = getProvider(provider);
+    if (cp?.authCheck) {
+      authStatus = await invoke<boolean>(cp.authCheck, { provider }).catch(() => false);
+    } else {
+      authStatus = null;
+    }
+  }
+
+  async function handleProviderSwitch(id: string) {
+    provider = id;
+    await invoke("save_provider", { provider: id });
+    await loadProviderConfig();
+    showSaved();
+  }
+
+  async function handleSaveConfig() {
+    saving = true;
+    error = "";
+    try {
+      await invoke("save_provider_config", { provider, configValues });
+      showSaved();
+    } catch (e) {
+      error = String(e);
+    } finally {
+      saving = false;
+    }
+  }
 
   async function handleOpacityChange(e: Event) {
     opacity = parseFloat((e.target as HTMLInputElement).value);
     localStorage.setItem("window-opacity", String(opacity));
     await getCurrentWindow().setOpacity(opacity);
-  }
-
-  async function handleProviderSwitch(p: typeof provider) {
-    provider = p;
-    await invoke("save_provider", { provider: p });
-    showSaved();
-  }
-
-  async function handleSaveApiKey() {
-    if (!apiKey.trim()) {
-      error = "API Key 不能为空";
-      return;
-    }
-    saving = true;
-    error = "";
-    try {
-      await invoke("save_api_key", { key: apiKey.trim() });
-      showSaved();
-    } catch (e) {
-      error = String(e);
-    } finally {
-      saving = false;
-    }
-  }
-
-  async function handleSaveVertexConfig() {
-    if (!gcpProjectId.trim()) {
-      error = "项目 ID 不能为空";
-      return;
-    }
-    saving = true;
-    error = "";
-    try {
-      await invoke("save_vertex_config", {
-        projectId: gcpProjectId.trim(),
-        location: gcpLocation.trim() || "us-central1",
-        model: vertexModel,
-      });
-      showSaved();
-    } catch (e) {
-      error = String(e);
-    } finally {
-      saving = false;
-    }
   }
 
   async function handlePolishToggle() {
@@ -115,6 +90,7 @@
   async function handleShortcutChange() {
     try {
       await invoke("save_shortcut", { shortcut });
+      shortcutConflict = "";
       showSaved();
     } catch (e) {
       error = String(e);
@@ -154,15 +130,9 @@
   <div class="header" role="toolbar" aria-label="设置标题栏" on:mousedown={handleHeaderMousedown}>
     <span class="title">设置</span>
     {#if appState === "recording"}
-      <div class="rec-badge">
-        <div class="rec-dot"></div>
-        <span>录音中</span>
-      </div>
+      <div class="rec-badge"><div class="rec-dot"></div><span>录音中</span></div>
     {:else if appState === "processing"}
-      <div class="rec-badge processing">
-        <div class="proc-spinner"></div>
-        <span>转录中</span>
-      </div>
+      <div class="rec-badge processing"><div class="proc-spinner"></div><span>转录中</span></div>
     {/if}
     <button class="close-btn" on:click={() => dispatch("close")}>
       <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
@@ -172,138 +142,120 @@
   </div>
 
   <div class="sections">
-    <!-- Provider selector -->
+    <!-- Provider selector (dynamic) -->
     <div class="section">
-      <label class="section-label">语音服务</label>
-      <div class="provider-tabs">
-        <button
-          class="provider-tab"
-          class:active={provider === "groq"}
-          on:click={() => handleProviderSwitch("groq")}
-        >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
-            <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-          Groq
-        </button>
-        <button
-          class="provider-tab"
-          class:active={provider === "vertex_ai"}
-          on:click={() => handleProviderSwitch("vertex_ai")}
-        >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
-            <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/>
-            <polyline points="3.27 6.96 12 12.01 20.73 6.96" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-            <line x1="12" y1="22.08" x2="12" y2="12" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
-          </svg>
-          Vertex AI
-        </button>
+      <span class="section-label">语音服务</span>
+      <div class="provider-tabs" class:scrollable={providers.length > 3}>
+        {#each providers as p}
+          <button
+            class="provider-tab"
+            class:active={provider === p.id}
+            on:click={() => handleProviderSwitch(p.id)}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none">{@html p.icon}</svg>
+            {p.name}
+          </button>
+        {/each}
       </div>
     </div>
 
-    <!-- Groq config -->
-    {#if provider === "groq"}
+    <!-- Provider config (dynamic fields) -->
+    {#if currentProvider}
       <div class="section provider-config">
-        <label class="section-label">Groq API Key</label>
-        <div class="input-row">
-          <input
-            type="password"
-            placeholder="gsk_..."
-            bind:value={apiKey}
-            on:keydown={(e) => e.key === "Enter" && handleSaveApiKey()}
-            autocomplete="off"
-            spellcheck="false"
-            class="text-input"
-          />
-          <button class="action-btn" on:click={handleSaveApiKey} disabled={saving}>
-            {saving ? "..." : "保存"}
-          </button>
-        </div>
-        <p class="hint">
-          在 <a href="https://console.groq.com" target="_blank" rel="noopener">console.groq.com</a> 免费获取
-        </p>
-      </div>
-    {/if}
+        {#each fieldGroups as group}
+          {#if group.length === 1}
+            <div class="field">
+              <span class="field-label">{group[0].label}</span>
+              {#if group[0].type === "select"}
+                <select class="select-input" bind:value={configValues[group[0].key]}>
+                  {#each group[0].options ?? [] as opt}
+                    <option value={opt.value}>{opt.label}</option>
+                  {/each}
+                </select>
+              {:else if group[0].type === "password"}
+                <input
+                  type="password"
+                  class="text-input"
+                  placeholder={group[0].placeholder ?? ""}
+                  bind:value={configValues[group[0].key]}
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+              {:else}
+                <input
+                  type="text"
+                  class="text-input"
+                  class:mono={group[0].mono}
+                  placeholder={group[0].placeholder ?? ""}
+                  bind:value={configValues[group[0].key]}
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+              {/if}
+            </div>
+          {:else}
+            <div class="field-row">
+              {#each group as field}
+                <div class="field flex1">
+                  <span class="field-label">{field.label}</span>
+                  {#if field.type === "select"}
+                    <select class="select-input" bind:value={configValues[field.key]}>
+                      {#each field.options ?? [] as opt}
+                        <option value={opt.value}>{opt.label}</option>
+                      {/each}
+                    </select>
+                  {:else}
+                    <input
+                      type="text"
+                      class="text-input"
+                      class:mono={field.mono}
+                      placeholder={field.placeholder ?? ""}
+                      bind:value={configValues[field.key]}
+                      autocomplete="off"
+                      spellcheck="false"
+                    />
+                  {/if}
+                </div>
+              {/each}
+            </div>
+          {/if}
+        {/each}
 
-    <!-- Vertex AI config -->
-    {#if provider === "vertex_ai"}
-      <div class="section provider-config">
-        <div class="vertex-fields">
-          <div class="field">
-            <label class="field-label">GCP 项目 ID</label>
-            <input
-              type="text"
-              placeholder="my-project-id"
-              bind:value={gcpProjectId}
-              class="text-input"
-              autocomplete="off"
-              spellcheck="false"
-            />
+        <button class="action-btn full-width" on:click={handleSaveConfig} disabled={saving}>
+          {saving ? "保存中..." : "保存"}
+        </button>
+
+        {#if authStatus !== null && currentProvider.authOkText}
+          <div class="auth-status" class:ok={authStatus}>
+            <div class="auth-dot"></div>
+            <span>{authStatus ? currentProvider.authOkText : currentProvider.authFailText}</span>
           </div>
-          <div class="field-row">
-            <div class="field flex1">
-              <label class="field-label">区域</label>
-              <input
-                type="text"
-                placeholder="us-central1"
-                bind:value={gcpLocation}
-                class="text-input mono"
-                autocomplete="off"
-                spellcheck="false"
-              />
-            </div>
-            <div class="field flex1">
-              <label class="field-label">模型</label>
-              <select class="select-input" bind:value={vertexModel}>
-                {#each vertexModels as m}
-                  <option value={m.value}>{m.label}</option>
-                {/each}
-              </select>
-            </div>
-          </div>
-          <button class="action-btn full-width" on:click={handleSaveVertexConfig} disabled={saving}>
-            {saving ? "保存中..." : "保存配置"}
-          </button>
-        </div>
-        <div class="adc-status" class:ok={adcAvailable}>
-          <div class="adc-dot"></div>
-          <span>
-            {#if adcAvailable}
-              gcloud 凭证已就绪
-            {:else}
-              未检测到 gcloud 凭证
-            {/if}
-          </span>
-        </div>
-        {#if !adcAvailable}
-          <p class="hint">请运行 <code>gcloud auth application-default login</code></p>
+        {/if}
+
+        {#if currentProvider.hint}
+          <p class="hint">{@html currentProvider.hint}</p>
         {/if}
       </div>
     {/if}
 
     <div class="divider"></div>
 
-    <!-- Polish toggle -->
+    <!-- Polish -->
     <div class="section row-section">
       <div class="row-label-block">
         <span class="section-label">AI 润色</span>
         <span class="row-desc">自动添加标点、修正错字</span>
       </div>
-      <button
-        class="toggle"
-        class:on={polishEnabled}
-        on:click={handlePolishToggle}
-        aria-label="切换润色"
-      >
+      <button class="toggle" class:on={polishEnabled} on:click={handlePolishToggle} aria-label="切换润色">
         <div class="toggle-knob"></div>
       </button>
     </div>
 
     <div class="divider"></div>
 
-    <!-- Microphone selection -->
+    <!-- Microphone -->
     <div class="section">
-      <label class="section-label">麦克风</label>
+      <span class="section-label">麦克风</span>
       <select class="select-input" on:change={handleDeviceChange} value={preferredDevice ?? "__default__"}>
         <option value="__default__">系统默认</option>
         {#each audioDevices as device}
@@ -316,52 +268,39 @@
 
     <!-- Shortcut -->
     <div class="section">
-      <label class="section-label">全局快捷键</label>
+      <span class="section-label">全局快捷键</span>
       <div class="input-row">
-        <input
-          type="text"
-          bind:value={shortcut}
-          class="text-input mono"
-          placeholder="Meta+Shift+Space"
-        />
+        <input type="text" bind:value={shortcut} class="text-input mono" placeholder="Meta+Shift+Space" />
         <button class="action-btn" on:click={handleShortcutChange}>应用</button>
       </div>
+      {#if shortcutConflict}
+        <div class="conflict-banner">快捷键 <kbd>{shortcutConflict}</kbd> 可能已被其他应用占用，请尝试更换</div>
+      {/if}
       <p class="hint">Meta = ⌘，Ctrl，Alt，Shift</p>
     </div>
 
     <div class="divider"></div>
 
-    <!-- Autostart toggle -->
+    <!-- Autostart -->
     <div class="section row-section">
       <div class="row-label-block">
         <span class="section-label">开机自启</span>
         <span class="row-desc">登录时自动启动</span>
       </div>
-      <button
-        class="toggle"
-        class:on={autostartEnabled}
-        on:click={handleAutostartToggle}
-        aria-label="切换开机自启"
-      >
+      <button class="toggle" class:on={autostartEnabled} on:click={handleAutostartToggle} aria-label="切换开机自启">
         <div class="toggle-knob"></div>
       </button>
     </div>
 
     <div class="divider"></div>
 
-    <!-- Screenshot context toggle -->
+    <!-- Screenshot context -->
     <div class="section row-section">
       <div class="row-label-block">
         <span class="section-label">截图上下文</span>
         <span class="row-desc">录音时截屏，提升润色准确度</span>
       </div>
-      <button
-        class="toggle"
-        class:on={screenshotContextEnabled}
-        on:click={handleScreenshotContextToggle}
-        aria-label="切换截图上下文"
-        disabled={!polishEnabled}
-      >
+      <button class="toggle" class:on={screenshotContextEnabled} on:click={handleScreenshotContextToggle} aria-label="切换截图上下文" disabled={!polishEnabled}>
         <div class="toggle-knob"></div>
       </button>
     </div>
@@ -374,417 +313,89 @@
         <span class="section-label">窗口不透明度</span>
         <span class="row-desc">{Math.round(opacity * 100)}%</span>
       </div>
-      <input
-        type="range"
-        min="0.2"
-        max="1"
-        step="0.05"
-        value={opacity}
-        on:input={handleOpacityChange}
-        class="opacity-slider"
-      />
+      <input type="range" min="0.2" max="1" step="0.05" value={opacity} on:input={handleOpacityChange} class="opacity-slider" />
     </div>
   </div>
 
-  {#if error}
-    <div class="error-banner">{error}</div>
-  {/if}
-
-  {#if saved}
-    <div class="saved-banner">已保存</div>
-  {/if}
+  {#if error}<div class="error-banner">{error}</div>{/if}
+  {#if saved}<div class="saved-banner">已保存</div>{/if}
 </div>
 
 <style>
   .settings-panel {
     width: 320px;
-    background: rgba(30, 30, 32, 0.92);
+    background: rgba(30,30,32,0.92);
     backdrop-filter: blur(20px) saturate(180%);
     -webkit-backdrop-filter: blur(20px) saturate(180%);
     border-radius: 16px;
-    box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5);
+    box-shadow: 0 8px 40px rgba(0,0,0,0.5);
     overflow: hidden;
-    font-family: -apple-system, "SF Pro Text", BlinkMacSystemFont, sans-serif;
+    font-family: -apple-system,"SF Pro Text",BlinkMacSystemFont,sans-serif;
     -webkit-font-smoothing: antialiased;
   }
-
-  .header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 14px 16px 12px;
-    border-bottom: 1px solid rgba(255,255,255,0.08);
-    cursor: grab;
-  }
-
-  .header:active {
-    cursor: grabbing;
-  }
-
-  .title {
-    font-size: 14px;
-    font-weight: 600;
-    color: rgba(255,255,255,0.88);
-    letter-spacing: 0.01em;
-  }
-
-  .rec-badge {
-    display: flex;
-    align-items: center;
-    gap: 5px;
-    padding: 3px 9px;
-    border-radius: 999px;
-    background: rgba(239, 68, 68, 0.15);
-    border: 1px solid rgba(239, 68, 68, 0.3);
-    font-size: 11px;
-    color: #f87171;
-    font-weight: 500;
-    margin-left: auto;
-    margin-right: 8px;
-  }
-
-  .rec-badge.processing {
-    background: rgba(99, 130, 246, 0.12);
-    border-color: rgba(99, 130, 246, 0.25);
-    color: #818cf8;
-  }
-
-  .rec-dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: #ef4444;
-    animation: blink 1.4s ease-in-out infinite;
-  }
-
-  .proc-spinner {
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    border: 1.5px solid rgba(99, 130, 246, 0.2);
-    border-top-color: #818cf8;
-    animation: spin 0.8s linear infinite;
-  }
-
+  .header { display:flex; align-items:center; justify-content:space-between; padding:14px 16px 12px; border-bottom:1px solid rgba(255,255,255,0.08); cursor:grab; }
+  .header:active { cursor:grabbing; }
+  .title { font-size:14px; font-weight:600; color:rgba(255,255,255,0.88); }
+  .rec-badge { display:flex; align-items:center; gap:5px; padding:3px 9px; border-radius:999px; background:rgba(239,68,68,0.15); border:1px solid rgba(239,68,68,0.3); font-size:11px; color:#f87171; font-weight:500; margin-left:auto; margin-right:8px; }
+  .rec-badge.processing { background:rgba(99,130,246,0.12); border-color:rgba(99,130,246,0.25); color:#818cf8; }
+  .rec-dot { width:6px; height:6px; border-radius:50%; background:#ef4444; animation:blink 1.4s ease-in-out infinite; }
+  .proc-spinner { width:10px; height:10px; border-radius:50%; border:1.5px solid rgba(99,130,246,0.2); border-top-color:#818cf8; animation:spin .8s linear infinite; }
   @keyframes blink { 0%,100%{opacity:1} 50%{opacity:.5} }
-  @keyframes spin { to { transform: rotate(360deg); } }
-
-  .close-btn {
-    background: rgba(255,255,255,0.08);
-    border: none;
-    border-radius: 50%;
-    width: 22px;
-    height: 22px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    transition: background 0.15s;
-    padding: 0;
-  }
-
-  .close-btn:hover {
-    background: rgba(255,255,255,0.15);
-  }
-
-  .sections {
-    padding: 4px 0;
-    overflow-y: auto;
-    max-height: calc(100vh - 56px);
-  }
-
-  .section {
-    padding: 11px 16px;
-    display: flex;
-    flex-direction: column;
-    gap: 7px;
-  }
-
-  .section.row-section {
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-  .section-label {
-    font-size: 13px;
-    font-weight: 500;
-    color: rgba(255,255,255,0.8);
-    letter-spacing: 0.01em;
-  }
-
-  .row-label-block {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-  }
-
-  .row-desc {
-    font-size: 11px;
-    color: rgba(255,255,255,0.35);
-  }
-
-  .hint {
-    font-size: 11px;
-    color: rgba(255,255,255,0.35);
-    line-height: 1.5;
-    margin: 0;
-  }
-
-  .hint a {
-    color: rgba(129, 140, 248, 0.85);
-    text-decoration: none;
-  }
-
-  .hint code {
-    font-family: "SF Mono", "Fira Code", monospace;
-    font-size: 10px;
-    background: rgba(255,255,255,0.06);
-    padding: 1px 4px;
-    border-radius: 3px;
-    color: rgba(255,255,255,0.5);
-  }
-
-  .divider {
-    height: 1px;
-    background: rgba(255,255,255,0.07);
-    margin: 0 16px;
-  }
-
-  .input-row {
-    display: flex;
-    gap: 8px;
-  }
-
-  .text-input {
-    flex: 1;
-    padding: 7px 10px;
-    border-radius: 8px;
-    border: 1px solid rgba(255,255,255,0.1);
-    background: rgba(255,255,255,0.05);
-    color: rgba(255,255,255,0.88);
-    font-size: 13px;
-    font-family: -apple-system, "SF Pro Text", BlinkMacSystemFont, sans-serif;
-    outline: none;
-    transition: border-color 0.15s;
-    min-width: 0;
-  }
-
-  .text-input.mono {
-    font-family: "SF Mono", "Fira Code", monospace;
-    font-size: 12px;
-  }
-
-  .text-input:focus {
-    border-color: rgba(129, 140, 248, 0.5);
-  }
-
-  .text-input::placeholder {
-    color: rgba(255,255,255,0.2);
-  }
-
-  .select-input {
-    width: 100%;
-    padding: 7px 10px;
-    border-radius: 8px;
-    border: 1px solid rgba(255,255,255,0.1);
-    background: rgba(255,255,255,0.05);
-    color: rgba(255,255,255,0.88);
-    font-size: 13px;
-    font-family: -apple-system, "SF Pro Text", BlinkMacSystemFont, sans-serif;
-    outline: none;
-    cursor: pointer;
-    appearance: auto;
-  }
-
-  .action-btn {
-    padding: 7px 14px;
-    border-radius: 8px;
-    border: none;
-    background: rgba(99, 102, 241, 0.75);
-    color: white;
-    font-size: 13px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: background 0.15s;
-    white-space: nowrap;
-    flex-shrink: 0;
-  }
-
-  .action-btn:hover:not(:disabled) {
-    background: rgba(99, 102, 241, 0.9);
-  }
-
-  .action-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  .action-btn.full-width {
-    width: 100%;
-  }
+  @keyframes spin { to { transform:rotate(360deg); } }
+  .close-btn { background:rgba(255,255,255,0.08); border:none; border-radius:50%; width:22px; height:22px; display:flex; align-items:center; justify-content:center; cursor:pointer; transition:background .15s; padding:0; }
+  .close-btn:hover { background:rgba(255,255,255,0.15); }
+  .sections { padding:4px 0; overflow-y:auto; max-height:calc(100vh - 56px); }
+  .section { padding:11px 16px; display:flex; flex-direction:column; gap:7px; }
+  .section.row-section { flex-direction:row; align-items:center; justify-content:space-between; }
+  .section-label { font-size:13px; font-weight:500; color:rgba(255,255,255,0.8); }
+  .row-label-block { display:flex; flex-direction:column; gap:2px; }
+  .row-desc { font-size:11px; color:rgba(255,255,255,0.35); }
+  .hint { font-size:11px; color:rgba(255,255,255,0.35); line-height:1.5; margin:0; }
+  .hint :global(a) { color:rgba(129,140,248,0.85); text-decoration:none; }
+  .hint :global(code) { font-family:"SF Mono","Fira Code",monospace; font-size:10px; background:rgba(255,255,255,0.06); padding:1px 4px; border-radius:3px; color:rgba(255,255,255,0.5); }
+  .divider { height:1px; background:rgba(255,255,255,0.07); margin:0 16px; }
+  .input-row { display:flex; gap:8px; }
+  .text-input { flex:1; padding:7px 10px; border-radius:8px; border:1px solid rgba(255,255,255,0.1); background:rgba(255,255,255,0.05); color:rgba(255,255,255,0.88); font-size:13px; font-family:-apple-system,"SF Pro Text",BlinkMacSystemFont,sans-serif; outline:none; transition:border-color .15s; min-width:0; }
+  .text-input.mono { font-family:"SF Mono","Fira Code",monospace; font-size:12px; }
+  .text-input:focus { border-color:rgba(129,140,248,0.5); }
+  .text-input::placeholder { color:rgba(255,255,255,0.2); }
+  .select-input { width:100%; padding:7px 10px; border-radius:8px; border:1px solid rgba(255,255,255,0.1); background:rgba(255,255,255,0.05); color:rgba(255,255,255,0.88); font-size:13px; font-family:-apple-system,"SF Pro Text",BlinkMacSystemFont,sans-serif; outline:none; cursor:pointer; appearance:auto; }
+  .action-btn { padding:7px 14px; border-radius:8px; border:none; background:rgba(99,102,241,0.75); color:white; font-size:13px; font-weight:500; cursor:pointer; transition:background .15s; white-space:nowrap; flex-shrink:0; }
+  .action-btn:hover:not(:disabled) { background:rgba(99,102,241,0.9); }
+  .action-btn:disabled { opacity:0.5; cursor:not-allowed; }
+  .action-btn.full-width { width:100%; }
 
   /* Provider tabs */
-  .provider-tabs {
-    display: flex;
-    gap: 0;
-    background: rgba(255,255,255,0.04);
-    border-radius: 10px;
-    padding: 3px;
-    border: 1px solid rgba(255,255,255,0.06);
-  }
+  .provider-tabs { display:flex; gap:0; background:rgba(255,255,255,0.04); border-radius:10px; padding:3px; border:1px solid rgba(255,255,255,0.06); }
+  .provider-tabs.scrollable { overflow-x:auto; }
+  .provider-tabs.scrollable .provider-tab { flex:0 0 auto; }
+  .provider-tab { flex:1; display:flex; align-items:center; justify-content:center; gap:6px; padding:7px 12px; border:none; border-radius:8px; background:transparent; color:rgba(255,255,255,0.4); font-size:12.5px; font-weight:500; cursor:pointer; transition:all .2s ease; font-family:-apple-system,"SF Pro Text",BlinkMacSystemFont,sans-serif; }
+  .provider-tab:hover { color:rgba(255,255,255,0.6); }
+  .provider-tab.active { background:rgba(99,102,241,0.2); color:rgba(165,180,252,0.95); box-shadow:0 1px 3px rgba(0,0,0,0.15); }
+  .provider-config { padding-top:6px; }
 
-  .provider-tab {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 6px;
-    padding: 7px 12px;
-    border: none;
-    border-radius: 8px;
-    background: transparent;
-    color: rgba(255,255,255,0.4);
-    font-size: 12.5px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    font-family: -apple-system, "SF Pro Text", BlinkMacSystemFont, sans-serif;
-  }
+  /* Dynamic fields */
+  .field { display:flex; flex-direction:column; gap:4px; }
+  .field-label { font-size:11px; color:rgba(255,255,255,0.4); font-weight:500; }
+  .field-row { display:flex; gap:8px; }
+  .flex1 { flex:1; min-width:0; }
 
-  .provider-tab:hover {
-    color: rgba(255,255,255,0.6);
-  }
+  /* Auth status */
+  .auth-status { display:flex; align-items:center; gap:6px; font-size:11px; color:rgba(248,113,113,0.8); padding:6px 10px; border-radius:8px; background:rgba(248,113,113,0.06); border:1px solid rgba(248,113,113,0.12); }
+  .auth-status.ok { color:rgba(134,239,172,0.85); background:rgba(74,222,128,0.06); border-color:rgba(74,222,128,0.15); }
+  .auth-dot { width:6px; height:6px; border-radius:50%; background:rgba(248,113,113,0.7); flex-shrink:0; }
+  .auth-status.ok .auth-dot { background:rgba(74,222,128,0.7); }
 
-  .provider-tab.active {
-    background: rgba(99, 102, 241, 0.2);
-    color: rgba(165, 180, 252, 0.95);
-    box-shadow: 0 1px 3px rgba(0,0,0,0.15);
-  }
+  /* Toggle */
+  .toggle { position:relative; width:40px; height:24px; border-radius:12px; border:none; background:rgba(255,255,255,0.1); cursor:pointer; transition:background .2s; flex-shrink:0; padding:0; }
+  .toggle.on { background:rgba(99,102,241,0.85); }
+  .toggle-knob { position:absolute; top:3px; left:3px; width:18px; height:18px; border-radius:50%; background:white; box-shadow:0 1px 3px rgba(0,0,0,0.3); transition:transform .2s cubic-bezier(.4,0,.2,1); }
+  .toggle.on .toggle-knob { transform:translateX(16px); }
 
-  /* Provider config area */
-  .provider-config {
-    padding-top: 6px;
-  }
-
-  /* Vertex AI specific */
-  .vertex-fields {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-  }
-
-  .field {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-  }
-
-  .field-label {
-    font-size: 11px;
-    color: rgba(255,255,255,0.4);
-    font-weight: 500;
-  }
-
-  .field-row {
-    display: flex;
-    gap: 8px;
-  }
-
-  .flex1 {
-    flex: 1;
-    min-width: 0;
-  }
-
-  .adc-status {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 11px;
-    color: rgba(248, 113, 113, 0.8);
-    padding: 6px 10px;
-    border-radius: 8px;
-    background: rgba(248, 113, 113, 0.06);
-    border: 1px solid rgba(248, 113, 113, 0.12);
-  }
-
-  .adc-status.ok {
-    color: rgba(134, 239, 172, 0.85);
-    background: rgba(74, 222, 128, 0.06);
-    border-color: rgba(74, 222, 128, 0.15);
-  }
-
-  .adc-dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: rgba(248, 113, 113, 0.7);
-    flex-shrink: 0;
-  }
-
-  .adc-status.ok .adc-dot {
-    background: rgba(74, 222, 128, 0.7);
-  }
-
-  /* Toggle switch */
-  .toggle {
-    position: relative;
-    width: 40px;
-    height: 24px;
-    border-radius: 12px;
-    border: none;
-    background: rgba(255,255,255,0.1);
-    cursor: pointer;
-    transition: background 0.2s;
-    flex-shrink: 0;
-    padding: 0;
-  }
-
-  .toggle.on {
-    background: rgba(99, 102, 241, 0.85);
-  }
-
-  .toggle-knob {
-    position: absolute;
-    top: 3px;
-    left: 3px;
-    width: 18px;
-    height: 18px;
-    border-radius: 50%;
-    background: white;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.3);
-    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  }
-
-  .toggle.on .toggle-knob {
-    transform: translateX(16px);
-  }
-
-  /* Status banners */
-  .error-banner {
-    margin: 0 16px 12px;
-    padding: 7px 10px;
-    border-radius: 8px;
-    background: rgba(248, 113, 113, 0.12);
-    border: 1px solid rgba(248, 113, 113, 0.25);
-    font-size: 12px;
-    color: #f87171;
-  }
-
-  .saved-banner {
-    margin: 0 16px 12px;
-    padding: 7px 10px;
-    border-radius: 8px;
-    background: rgba(74, 222, 128, 0.1);
-    border: 1px solid rgba(74, 222, 128, 0.25);
-    font-size: 12px;
-    color: rgba(134, 239, 172, 0.9);
-    text-align: center;
-  }
-
-  .opacity-slider {
-    width: 100%;
-    accent-color: rgba(99, 102, 241, 0.85);
-    cursor: pointer;
-  }
+  /* Banners */
+  .conflict-banner { padding:6px 10px; border-radius:8px; background:rgba(251,191,36,0.08); border:1px solid rgba(251,191,36,0.2); font-size:11px; color:rgba(251,191,36,0.85); line-height:1.5; }
+  .conflict-banner :global(kbd) { display:inline-block; padding:1px 5px; border-radius:4px; border:1px solid rgba(255,255,255,0.15); background:rgba(255,255,255,0.06); font-family:-apple-system,sans-serif; font-size:11px; }
+  .error-banner { margin:0 16px 12px; padding:7px 10px; border-radius:8px; background:rgba(248,113,113,0.12); border:1px solid rgba(248,113,113,0.25); font-size:12px; color:#f87171; }
+  .saved-banner { margin:0 16px 12px; padding:7px 10px; border-radius:8px; background:rgba(74,222,128,0.1); border:1px solid rgba(74,222,128,0.25); font-size:12px; color:rgba(134,239,172,0.9); text-align:center; }
+  .opacity-slider { width:100%; accent-color:rgba(99,102,241,0.85); cursor:pointer; }
 </style>

--- a/src/lib/SettingsPanel.svelte
+++ b/src/lib/SettingsPanel.svelte
@@ -2,7 +2,8 @@
   import { createEventDispatcher, onMount } from "svelte";
   import { invoke } from "@tauri-apps/api/core";
   import { getCurrentWindow } from "@tauri-apps/api/window";
-  import { providers, getProvider, groupFields, type ProviderDef, type ProviderField } from "./providers";
+  import { providers, getProvider, groupFields } from "./providers";
+  import { t, locale, type Locale } from "./i18n";
 
   const dispatch = createEventDispatcher();
 
@@ -107,6 +108,10 @@
     await invoke("save_screenshot_context_enabled", { enabled: screenshotContextEnabled });
   }
 
+  function switchLocale(loc: Locale) {
+    $locale = loc;
+  }
+
   function showSaved() {
     saved = true;
     setTimeout(() => { saved = false; }, 1800);
@@ -127,12 +132,12 @@
 <div class="settings-panel">
   <!-- Header -->
   <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
-  <div class="header" role="toolbar" aria-label="设置标题栏" on:mousedown={handleHeaderMousedown}>
-    <span class="title">设置</span>
+  <div class="header" role="toolbar" aria-label="Settings" on:mousedown={handleHeaderMousedown}>
+    <span class="title">{$t('settings.title')}</span>
     {#if appState === "recording"}
-      <div class="rec-badge"><div class="rec-dot"></div><span>录音中</span></div>
+      <div class="rec-badge"><div class="rec-dot"></div><span>{$t('settings.recording')}</span></div>
     {:else if appState === "processing"}
-      <div class="rec-badge processing"><div class="proc-spinner"></div><span>转录中</span></div>
+      <div class="rec-badge processing"><div class="proc-spinner"></div><span>{$t('settings.transcribing')}</span></div>
     {/if}
     <button class="close-btn" on:click={() => dispatch("close")}>
       <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
@@ -142,9 +147,20 @@
   </div>
 
   <div class="sections">
+    <!-- Language -->
+    <div class="section row-section">
+      <span class="section-label">{$t('settings.language')}</span>
+      <div class="lang-toggle">
+        <button class:active={$locale === 'en'} on:click={() => switchLocale('en')}>EN</button>
+        <button class:active={$locale === 'zh'} on:click={() => switchLocale('zh')}>中文</button>
+      </div>
+    </div>
+
+    <div class="divider"></div>
+
     <!-- Provider selector (dynamic) -->
     <div class="section">
-      <span class="section-label">语音服务</span>
+      <span class="section-label">{$t('settings.voice_service')}</span>
       <div class="provider-tabs" class:scrollable={providers.length > 3}>
         {#each providers as p}
           <button
@@ -165,7 +181,7 @@
         {#each fieldGroups as group}
           {#if group.length === 1}
             <div class="field">
-              <span class="field-label">{group[0].label}</span>
+              <span class="field-label">{group[0].label[$locale]}</span>
               {#if group[0].type === "select"}
                 <select class="select-input" bind:value={configValues[group[0].key]}>
                   {#each group[0].options ?? [] as opt}
@@ -197,7 +213,7 @@
             <div class="field-row">
               {#each group as field}
                 <div class="field flex1">
-                  <span class="field-label">{field.label}</span>
+                  <span class="field-label">{field.label[$locale]}</span>
                   {#if field.type === "select"}
                     <select class="select-input" bind:value={configValues[field.key]}>
                       {#each field.options ?? [] as opt}
@@ -222,18 +238,18 @@
         {/each}
 
         <button class="action-btn full-width" on:click={handleSaveConfig} disabled={saving}>
-          {saving ? "保存中..." : "保存"}
+          {saving ? $t('settings.saving') : $t('settings.save')}
         </button>
 
         {#if authStatus !== null && currentProvider.authOkText}
           <div class="auth-status" class:ok={authStatus}>
             <div class="auth-dot"></div>
-            <span>{authStatus ? currentProvider.authOkText : currentProvider.authFailText}</span>
+            <span>{authStatus ? currentProvider.authOkText[$locale] : (currentProvider.authFailText ?? currentProvider.authOkText)[$locale]}</span>
           </div>
         {/if}
 
         {#if currentProvider.hint}
-          <p class="hint">{@html currentProvider.hint}</p>
+          <p class="hint">{@html currentProvider.hint[$locale]}</p>
         {/if}
       </div>
     {/if}
@@ -243,10 +259,10 @@
     <!-- Polish -->
     <div class="section row-section">
       <div class="row-label-block">
-        <span class="section-label">AI 润色</span>
-        <span class="row-desc">自动添加标点、修正错字</span>
+        <span class="section-label">{$t('settings.polish')}</span>
+        <span class="row-desc">{$t('settings.polish_desc')}</span>
       </div>
-      <button class="toggle" class:on={polishEnabled} on:click={handlePolishToggle} aria-label="切换润色">
+      <button class="toggle" class:on={polishEnabled} on:click={handlePolishToggle} aria-label="Toggle polish">
         <div class="toggle-knob"></div>
       </button>
     </div>
@@ -255,9 +271,9 @@
 
     <!-- Microphone -->
     <div class="section">
-      <span class="section-label">麦克风</span>
+      <span class="section-label">{$t('settings.mic')}</span>
       <select class="select-input" on:change={handleDeviceChange} value={preferredDevice ?? "__default__"}>
-        <option value="__default__">系统默认</option>
+        <option value="__default__">{$t('settings.mic_default')}</option>
         {#each audioDevices as device}
           <option value={device}>{device}</option>
         {/each}
@@ -268,15 +284,15 @@
 
     <!-- Shortcut -->
     <div class="section">
-      <span class="section-label">全局快捷键</span>
+      <span class="section-label">{$t('settings.shortcut')}</span>
       <div class="input-row">
         <input type="text" bind:value={shortcut} class="text-input mono" placeholder="Meta+Shift+Space" />
-        <button class="action-btn" on:click={handleShortcutChange}>应用</button>
+        <button class="action-btn" on:click={handleShortcutChange}>{$t('settings.shortcut_apply')}</button>
       </div>
       {#if shortcutConflict}
-        <div class="conflict-banner">快捷键 <kbd>{shortcutConflict}</kbd> 可能已被其他应用占用，请尝试更换</div>
+        <div class="conflict-banner">{$t('settings.shortcut_conflict', shortcutConflict)}</div>
       {/if}
-      <p class="hint">Meta = ⌘，Ctrl，Alt，Shift</p>
+      <p class="hint">{$t('settings.shortcut_hint')}</p>
     </div>
 
     <div class="divider"></div>
@@ -284,10 +300,10 @@
     <!-- Autostart -->
     <div class="section row-section">
       <div class="row-label-block">
-        <span class="section-label">开机自启</span>
-        <span class="row-desc">登录时自动启动</span>
+        <span class="section-label">{$t('settings.autostart')}</span>
+        <span class="row-desc">{$t('settings.autostart_desc')}</span>
       </div>
-      <button class="toggle" class:on={autostartEnabled} on:click={handleAutostartToggle} aria-label="切换开机自启">
+      <button class="toggle" class:on={autostartEnabled} on:click={handleAutostartToggle} aria-label="Toggle autostart">
         <div class="toggle-knob"></div>
       </button>
     </div>
@@ -297,10 +313,10 @@
     <!-- Screenshot context -->
     <div class="section row-section">
       <div class="row-label-block">
-        <span class="section-label">截图上下文</span>
-        <span class="row-desc">录音时截屏，提升润色准确度</span>
+        <span class="section-label">{$t('settings.screenshot')}</span>
+        <span class="row-desc">{$t('settings.screenshot_desc')}</span>
       </div>
-      <button class="toggle" class:on={screenshotContextEnabled} on:click={handleScreenshotContextToggle} aria-label="切换截图上下文" disabled={!polishEnabled}>
+      <button class="toggle" class:on={screenshotContextEnabled} on:click={handleScreenshotContextToggle} aria-label="Toggle screenshot context" disabled={!polishEnabled}>
         <div class="toggle-knob"></div>
       </button>
     </div>
@@ -310,7 +326,7 @@
     <!-- Opacity -->
     <div class="section">
       <div class="row-label-block">
-        <span class="section-label">窗口不透明度</span>
+        <span class="section-label">{$t('settings.opacity')}</span>
         <span class="row-desc">{Math.round(opacity * 100)}%</span>
       </div>
       <input type="range" min="0.2" max="1" step="0.05" value={opacity} on:input={handleOpacityChange} class="opacity-slider" />
@@ -318,7 +334,7 @@
   </div>
 
   {#if error}<div class="error-banner">{error}</div>{/if}
-  {#if saved}<div class="saved-banner">已保存</div>{/if}
+  {#if saved}<div class="saved-banner">{$t('settings.saved')}</div>{/if}
 </div>
 
 <style>
@@ -365,6 +381,12 @@
   .action-btn:disabled { opacity:0.5; cursor:not-allowed; }
   .action-btn.full-width { width:100%; }
 
+  /* Language toggle */
+  .lang-toggle { display:flex; background:rgba(255,255,255,0.04); border-radius:8px; padding:2px; border:1px solid rgba(255,255,255,0.06); }
+  .lang-toggle button { padding:4px 12px; border:none; border-radius:6px; background:transparent; color:rgba(255,255,255,0.4); font-size:12px; font-weight:500; cursor:pointer; transition:all .2s; font-family:-apple-system,"SF Pro Text",BlinkMacSystemFont,sans-serif; }
+  .lang-toggle button:hover { color:rgba(255,255,255,0.6); }
+  .lang-toggle button.active { background:rgba(99,102,241,0.2); color:rgba(165,180,252,0.95); }
+
   /* Provider tabs */
   .provider-tabs { display:flex; gap:0; background:rgba(255,255,255,0.04); border-radius:10px; padding:3px; border:1px solid rgba(255,255,255,0.06); }
   .provider-tabs.scrollable { overflow-x:auto; }
@@ -394,7 +416,6 @@
 
   /* Banners */
   .conflict-banner { padding:6px 10px; border-radius:8px; background:rgba(251,191,36,0.08); border:1px solid rgba(251,191,36,0.2); font-size:11px; color:rgba(251,191,36,0.85); line-height:1.5; }
-  .conflict-banner :global(kbd) { display:inline-block; padding:1px 5px; border-radius:4px; border:1px solid rgba(255,255,255,0.15); background:rgba(255,255,255,0.06); font-family:-apple-system,sans-serif; font-size:11px; }
   .error-banner { margin:0 16px 12px; padding:7px 10px; border-radius:8px; background:rgba(248,113,113,0.12); border:1px solid rgba(248,113,113,0.25); font-size:12px; color:#f87171; }
   .saved-banner { margin:0 16px 12px; padding:7px 10px; border-radius:8px; background:rgba(74,222,128,0.1); border:1px solid rgba(74,222,128,0.25); font-size:12px; color:rgba(134,239,172,0.9); text-align:center; }
   .opacity-slider { width:100%; accent-color:rgba(99,102,241,0.85); cursor:pointer; }

--- a/src/lib/SettingsPanel.svelte
+++ b/src/lib/SettingsPanel.svelte
@@ -13,7 +13,13 @@
   export let screenshotContextEnabled: boolean = false;
   export let appState: string = "idle";
 
+  let provider: "groq" | "vertex_ai" = "groq";
   let apiKey = "";
+  let gcpProjectId = "";
+  let gcpLocation = "us-central1";
+  let vertexModel = "gemini-2.5-flash";
+  let adcAvailable = false;
+
   let preferredDevice: string | null = null;
   let shortcut = "Meta+Shift+Space";
   let saving = false;
@@ -21,7 +27,14 @@
   let error = "";
   let opacity = 1.0;
 
+  const vertexModels = [
+    { value: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+    { value: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+    { value: "gemini-2.0-flash", label: "Gemini 2.0 Flash" },
+  ];
+
   onMount(async () => {
+    provider = (await invoke<string>("get_provider")) as typeof provider;
     apiKey = await invoke<string>("get_saved_api_key");
     shortcut = await invoke<string>("get_shortcut");
     const cfg = await invoke<string | null>("get_preferred_device").catch(() => null);
@@ -31,12 +44,23 @@
       opacity = parseFloat(savedOpacity);
       await getCurrentWindow().setOpacity(opacity);
     }
+    const vc = await invoke<{ project_id: string; location: string; model: string }>("get_vertex_config");
+    gcpProjectId = vc.project_id;
+    gcpLocation = vc.location || "us-central1";
+    vertexModel = vc.model || "gemini-2.5-flash";
+    adcAvailable = await invoke<boolean>("check_vertex_auth").catch(() => false);
   });
 
   async function handleOpacityChange(e: Event) {
     opacity = parseFloat((e.target as HTMLInputElement).value);
     localStorage.setItem("window-opacity", String(opacity));
     await getCurrentWindow().setOpacity(opacity);
+  }
+
+  async function handleProviderSwitch(p: typeof provider) {
+    provider = p;
+    await invoke("save_provider", { provider: p });
+    showSaved();
   }
 
   async function handleSaveApiKey() {
@@ -48,6 +72,27 @@
     error = "";
     try {
       await invoke("save_api_key", { key: apiKey.trim() });
+      showSaved();
+    } catch (e) {
+      error = String(e);
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function handleSaveVertexConfig() {
+    if (!gcpProjectId.trim()) {
+      error = "项目 ID 不能为空";
+      return;
+    }
+    saving = true;
+    error = "";
+    try {
+      await invoke("save_vertex_config", {
+        projectId: gcpProjectId.trim(),
+        location: gcpLocation.trim() || "us-central1",
+        model: vertexModel,
+      });
       showSaved();
     } catch (e) {
       error = String(e);
@@ -99,16 +144,6 @@
     if ((e.target as HTMLElement).closest("button")) return;
     await getCurrentWindow().startDragging();
   }
-
-  // Expose get_preferred_device as a stub — it's done via onMount
-  async function getPreferredDevice(): Promise<string | null> {
-    try {
-      const cfg = await invoke<{preferred_device: string | null}>("get_config");
-      return cfg.preferred_device;
-    } catch {
-      return null;
-    }
-  }
 </script>
 
 <svelte:window on:keydown={handleKeydown} />
@@ -137,27 +172,114 @@
   </div>
 
   <div class="sections">
-    <!-- API Key -->
+    <!-- Provider selector -->
     <div class="section">
-      <label class="section-label">Groq API Key</label>
-      <div class="input-row">
-        <input
-          type="password"
-          placeholder="gsk_..."
-          bind:value={apiKey}
-          on:keydown={(e) => e.key === "Enter" && handleSaveApiKey()}
-          autocomplete="off"
-          spellcheck="false"
-          class="text-input"
-        />
-        <button class="action-btn" on:click={handleSaveApiKey} disabled={saving}>
-          {saving ? "..." : "保存"}
+      <label class="section-label">语音服务</label>
+      <div class="provider-tabs">
+        <button
+          class="provider-tab"
+          class:active={provider === "groq"}
+          on:click={() => handleProviderSwitch("groq")}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+            <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          Groq
+        </button>
+        <button
+          class="provider-tab"
+          class:active={provider === "vertex_ai"}
+          on:click={() => handleProviderSwitch("vertex_ai")}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+            <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/>
+            <polyline points="3.27 6.96 12 12.01 20.73 6.96" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+            <line x1="12" y1="22.08" x2="12" y2="12" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+          </svg>
+          Vertex AI
         </button>
       </div>
-      <p class="hint">
-        在 <a href="https://console.groq.com" target="_blank" rel="noopener">console.groq.com</a> 免费获取
-      </p>
     </div>
+
+    <!-- Groq config -->
+    {#if provider === "groq"}
+      <div class="section provider-config">
+        <label class="section-label">Groq API Key</label>
+        <div class="input-row">
+          <input
+            type="password"
+            placeholder="gsk_..."
+            bind:value={apiKey}
+            on:keydown={(e) => e.key === "Enter" && handleSaveApiKey()}
+            autocomplete="off"
+            spellcheck="false"
+            class="text-input"
+          />
+          <button class="action-btn" on:click={handleSaveApiKey} disabled={saving}>
+            {saving ? "..." : "保存"}
+          </button>
+        </div>
+        <p class="hint">
+          在 <a href="https://console.groq.com" target="_blank" rel="noopener">console.groq.com</a> 免费获取
+        </p>
+      </div>
+    {/if}
+
+    <!-- Vertex AI config -->
+    {#if provider === "vertex_ai"}
+      <div class="section provider-config">
+        <div class="vertex-fields">
+          <div class="field">
+            <label class="field-label">GCP 项目 ID</label>
+            <input
+              type="text"
+              placeholder="my-project-id"
+              bind:value={gcpProjectId}
+              class="text-input"
+              autocomplete="off"
+              spellcheck="false"
+            />
+          </div>
+          <div class="field-row">
+            <div class="field flex1">
+              <label class="field-label">区域</label>
+              <input
+                type="text"
+                placeholder="us-central1"
+                bind:value={gcpLocation}
+                class="text-input mono"
+                autocomplete="off"
+                spellcheck="false"
+              />
+            </div>
+            <div class="field flex1">
+              <label class="field-label">模型</label>
+              <select class="select-input" bind:value={vertexModel}>
+                {#each vertexModels as m}
+                  <option value={m.value}>{m.label}</option>
+                {/each}
+              </select>
+            </div>
+          </div>
+          <button class="action-btn full-width" on:click={handleSaveVertexConfig} disabled={saving}>
+            {saving ? "保存中..." : "保存配置"}
+          </button>
+        </div>
+        <div class="adc-status" class:ok={adcAvailable}>
+          <div class="adc-dot"></div>
+          <span>
+            {#if adcAvailable}
+              gcloud 凭证已就绪
+            {:else}
+              未检测到 gcloud 凭证
+            {/if}
+          </span>
+        </div>
+        {#if !adcAvailable}
+          <p class="hint">请运行 <code>gcloud auth application-default login</code></p>
+        {/if}
+      </div>
+    {/if}
 
     <div class="divider"></div>
 
@@ -414,6 +536,15 @@
     text-decoration: none;
   }
 
+  .hint code {
+    font-family: "SF Mono", "Fira Code", monospace;
+    font-size: 10px;
+    background: rgba(255,255,255,0.06);
+    padding: 1px 4px;
+    border-radius: 3px;
+    color: rgba(255,255,255,0.5);
+  }
+
   .divider {
     height: 1px;
     background: rgba(255,255,255,0.07);
@@ -487,6 +618,112 @@
   .action-btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+
+  .action-btn.full-width {
+    width: 100%;
+  }
+
+  /* Provider tabs */
+  .provider-tabs {
+    display: flex;
+    gap: 0;
+    background: rgba(255,255,255,0.04);
+    border-radius: 10px;
+    padding: 3px;
+    border: 1px solid rgba(255,255,255,0.06);
+  }
+
+  .provider-tab {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 7px 12px;
+    border: none;
+    border-radius: 8px;
+    background: transparent;
+    color: rgba(255,255,255,0.4);
+    font-size: 12.5px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    font-family: -apple-system, "SF Pro Text", BlinkMacSystemFont, sans-serif;
+  }
+
+  .provider-tab:hover {
+    color: rgba(255,255,255,0.6);
+  }
+
+  .provider-tab.active {
+    background: rgba(99, 102, 241, 0.2);
+    color: rgba(165, 180, 252, 0.95);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+  }
+
+  /* Provider config area */
+  .provider-config {
+    padding-top: 6px;
+  }
+
+  /* Vertex AI specific */
+  .vertex-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .field-label {
+    font-size: 11px;
+    color: rgba(255,255,255,0.4);
+    font-weight: 500;
+  }
+
+  .field-row {
+    display: flex;
+    gap: 8px;
+  }
+
+  .flex1 {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .adc-status {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+    color: rgba(248, 113, 113, 0.8);
+    padding: 6px 10px;
+    border-radius: 8px;
+    background: rgba(248, 113, 113, 0.06);
+    border: 1px solid rgba(248, 113, 113, 0.12);
+  }
+
+  .adc-status.ok {
+    color: rgba(134, 239, 172, 0.85);
+    background: rgba(74, 222, 128, 0.06);
+    border-color: rgba(74, 222, 128, 0.15);
+  }
+
+  .adc-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: rgba(248, 113, 113, 0.7);
+    flex-shrink: 0;
+  }
+
+  .adc-status.ok .adc-dot {
+    background: rgba(74, 222, 128, 0.7);
   }
 
   /* Toggle switch */

--- a/src/lib/SettingsPanel.svelte
+++ b/src/lib/SettingsPanel.svelte
@@ -36,7 +36,7 @@
     const savedOpacity = localStorage.getItem("window-opacity");
     if (savedOpacity) {
       opacity = parseFloat(savedOpacity);
-      await getCurrentWindow().setOpacity(opacity);
+      document.documentElement.style.opacity = String(opacity);
     }
   });
 
@@ -74,7 +74,7 @@
   async function handleOpacityChange(e: Event) {
     opacity = parseFloat((e.target as HTMLInputElement).value);
     localStorage.setItem("window-opacity", String(opacity));
-    await getCurrentWindow().setOpacity(opacity);
+    document.documentElement.style.opacity = String(opacity);
   }
 
   async function handlePolishToggle() {

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -24,7 +24,7 @@ const messages: Record<Locale, Record<string, string>> = {
     // App / general
     "app.name": "Audio Input",
     "app.desc":
-      "Press shortcut, speak, text auto-inputs to any app.\nSupports Groq Whisper and Google Vertex AI.",
+      "Press shortcut, speak, text auto-inputs to any app.\nmacOS & Windows · Groq Whisper & Google Vertex AI.",
 
     // Accessibility banner (App.svelte)
     "ax.need": "Accessibility permission is needed to auto-inject text",
@@ -47,8 +47,8 @@ const messages: Record<Locale, Record<string, string>> = {
     "settings.shortcut": "Global Shortcut",
     "settings.shortcut_apply": "Apply",
     "settings.shortcut_hint": "Meta = ⌘, Ctrl, Alt, Shift",
-    "settings.shortcut_conflict":
-      "Shortcut {0} may be occupied by another app. Try a different one.",
+"settings.shortcut_conflict":
+                  "Shortcut {0} may be occupied by another app. Try a different one.",
     "settings.autostart": "Launch at Login",
     "settings.autostart_desc": "Auto-start when you log in",
     "settings.screenshot": "Screenshot Context",
@@ -89,7 +89,7 @@ const messages: Record<Locale, Record<string, string>> = {
   zh: {
     "app.name": "Audio Input",
     "app.desc":
-      "按下快捷键，说话，文字自动输入到任意应用。\n支持 Groq Whisper 和 Google Vertex AI。",
+      "按下快捷键，说话，文字自动输入到任意应用。\nmacOS 与 Windows · Groq Whisper 和 Google Vertex AI。",
 
     "ax.need": "需要辅助功能权限才能自动注入文字",
     "ax.restart": "授权后请完全退出并重启 App",
@@ -110,8 +110,8 @@ const messages: Record<Locale, Record<string, string>> = {
     "settings.shortcut": "全局快捷键",
     "settings.shortcut_apply": "应用",
     "settings.shortcut_hint": "Meta = ⌘，Ctrl，Alt，Shift",
-    "settings.shortcut_conflict":
-      "快捷键 {0} 可能已被其他应用占用，请尝试更换",
+"settings.shortcut_conflict":
+                  "快捷键 {0} 可能已被其他应用占用，请尝试更换",
     "settings.autostart": "开机自启",
     "settings.autostart_desc": "登录时自动启动",
     "settings.screenshot": "截图上下文",

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,169 @@
+import { writable, derived } from "svelte/store";
+
+export type Locale = "en" | "zh";
+
+/** Bilingual string — used in providers.ts and other data-driven definitions. */
+export type L = Record<Locale, string>;
+export function l(en: string, zh: string): L {
+  return { en, zh };
+}
+
+const stored =
+  typeof localStorage !== "undefined"
+    ? (localStorage.getItem("app-locale") as Locale | null)
+    : null;
+
+export const locale = writable<Locale>(stored || "en");
+
+locale.subscribe((v) => {
+  if (typeof localStorage !== "undefined") localStorage.setItem("app-locale", v);
+});
+
+const messages: Record<Locale, Record<string, string>> = {
+  en: {
+    // App / general
+    "app.name": "Audio Input",
+    "app.desc":
+      "Press shortcut, speak, text auto-inputs to any app.\nSupports Groq Whisper and Google Vertex AI.",
+
+    // Accessibility banner (App.svelte)
+    "ax.need": "Accessibility permission is needed to auto-inject text",
+    "ax.restart": "Fully quit and restart the app after granting",
+    "ax.open": "Open System Settings",
+    "ax.dismiss": "Dismiss",
+
+    // Settings panel
+    "settings.title": "Settings",
+    "settings.recording": "Recording",
+    "settings.transcribing": "Transcribing",
+    "settings.voice_service": "Voice Service",
+    "settings.save": "Save",
+    "settings.saving": "Saving…",
+    "settings.saved": "Saved",
+    "settings.polish": "AI Polish",
+    "settings.polish_desc": "Auto-punctuate and fix typos",
+    "settings.mic": "Microphone",
+    "settings.mic_default": "System Default",
+    "settings.shortcut": "Global Shortcut",
+    "settings.shortcut_apply": "Apply",
+    "settings.shortcut_hint": "Meta = ⌘, Ctrl, Alt, Shift",
+    "settings.shortcut_conflict":
+      "Shortcut {0} may be occupied by another app. Try a different one.",
+    "settings.autostart": "Launch at Login",
+    "settings.autostart_desc": "Auto-start when you log in",
+    "settings.screenshot": "Screenshot Context",
+    "settings.screenshot_desc":
+      "Capture screen while recording for better polish",
+    "settings.opacity": "Window Opacity",
+    "settings.language": "Language",
+
+    // Onboarding
+    "onboarding.start": "Get Started",
+    "onboarding.configure": "Configure AI Service",
+    "onboarding.save_continue": "Save & Continue",
+    "onboarding.skip": "Skip",
+    "onboarding.saved": "Saved",
+    "onboarding.ax_title": "Grant Accessibility",
+    "onboarding.ax_desc":
+      "Audio Input needs Accessibility permission to type text into other apps.",
+    "onboarding.ax_path1": "System Settings",
+    "onboarding.ax_path2": "Privacy & Security",
+    "onboarding.ax_path3": "Accessibility",
+    "onboarding.ax_path4": "+ Audio Input",
+    "onboarding.ax_done": "Done",
+    "onboarding.ax_open": "Open System Settings",
+    "onboarding.ready": "All Set!",
+    "onboarding.ready_mac":
+      "Press {0} to start recording. Release to auto-transcribe and type at cursor.\nClick the menu bar icon for settings.",
+    "onboarding.ready_win":
+      "Press {0} to start recording. Release to auto-transcribe and type at cursor.\nClick the system tray icon for settings.",
+    "onboarding.finish": "Start Using",
+
+    // HUD (RecordingIndicator)
+    "hud.transcribing": "Transcribing…",
+    "hud.error": "Error",
+    "hud.copied": "Copied — ⌘V to paste",
+    "hud.polish_failed": "Polish failed — original used",
+  },
+
+  zh: {
+    "app.name": "Audio Input",
+    "app.desc":
+      "按下快捷键，说话，文字自动输入到任意应用。\n支持 Groq Whisper 和 Google Vertex AI。",
+
+    "ax.need": "需要辅助功能权限才能自动注入文字",
+    "ax.restart": "授权后请完全退出并重启 App",
+    "ax.open": "打开系统设置",
+    "ax.dismiss": "忽略",
+
+    "settings.title": "设置",
+    "settings.recording": "录音中",
+    "settings.transcribing": "转录中",
+    "settings.voice_service": "语音服务",
+    "settings.save": "保存",
+    "settings.saving": "保存中…",
+    "settings.saved": "已保存",
+    "settings.polish": "AI 润色",
+    "settings.polish_desc": "自动添加标点、修正错字",
+    "settings.mic": "麦克风",
+    "settings.mic_default": "系统默认",
+    "settings.shortcut": "全局快捷键",
+    "settings.shortcut_apply": "应用",
+    "settings.shortcut_hint": "Meta = ⌘，Ctrl，Alt，Shift",
+    "settings.shortcut_conflict":
+      "快捷键 {0} 可能已被其他应用占用，请尝试更换",
+    "settings.autostart": "开机自启",
+    "settings.autostart_desc": "登录时自动启动",
+    "settings.screenshot": "截图上下文",
+    "settings.screenshot_desc": "录音时截屏，提升润色准确度",
+    "settings.opacity": "窗口不透明度",
+    "settings.language": "语言",
+
+    "onboarding.start": "开始配置",
+    "onboarding.configure": "配置 AI 服务",
+    "onboarding.save_continue": "保存并继续",
+    "onboarding.skip": "跳过",
+    "onboarding.saved": "已保存",
+    "onboarding.ax_title": "授权辅助功能",
+    "onboarding.ax_desc":
+      "Audio Input 需要辅助功能权限才能将文字注入到其他应用。",
+    "onboarding.ax_path1": "系统设置",
+    "onboarding.ax_path2": "隐私与安全性",
+    "onboarding.ax_path3": "辅助功能",
+    "onboarding.ax_path4": "+ Audio Input",
+    "onboarding.ax_done": "已完成",
+    "onboarding.ax_open": "打开系统设置",
+    "onboarding.ready": "准备就绪！",
+    "onboarding.ready_mac":
+      "按下 {0} 开始录音，松开自动转文字并输入到光标位置。\n点击菜单栏图标可打开设置。",
+    "onboarding.ready_win":
+      "按下 {0} 开始录音，松开自动转文字并输入到光标位置。\n点击系统托盘图标可打开设置。",
+    "onboarding.finish": "开始使用",
+
+    "hud.transcribing": "转录中…",
+    "hud.error": "错误",
+    "hud.copied": "已复制 — ⌘V 粘贴",
+    "hud.polish_failed": "润色失败 — 使用原文",
+  },
+};
+
+/**
+ * Derived translation store. Use as `$t('key')` in Svelte templates.
+ * Supports positional arguments: `$t('settings.shortcut_conflict', shortcut)`.
+ */
+export const t = derived(locale, ($locale) => {
+  const dict = messages[$locale];
+  const fallback = messages.en;
+  return (key: string, ...args: string[]): string => {
+    let msg = dict[key] ?? fallback[key] ?? key;
+    args.forEach((arg, i) => {
+      msg = msg.replace(`{${i}}`, arg);
+    });
+    return msg;
+  };
+});
+
+/** Resolve a bilingual `L` object using the current locale (non-reactive, for imperative code). */
+export function resolveL(ls: L, loc: Locale): string {
+  return ls[loc] ?? ls.en;
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -54,7 +54,6 @@ const messages: Record<Locale, Record<string, string>> = {
     "settings.screenshot": "Screenshot Context",
     "settings.screenshot_desc":
       "Capture screen while recording for better polish",
-    "settings.opacity": "Window Opacity",
     "settings.language": "Language",
 
     // Onboarding
@@ -116,7 +115,6 @@ const messages: Record<Locale, Record<string, string>> = {
     "settings.autostart_desc": "登录时自动启动",
     "settings.screenshot": "截图上下文",
     "settings.screenshot_desc": "录音时截屏，提升润色准确度",
-    "settings.opacity": "窗口不透明度",
     "settings.language": "语言",
 
     "onboarding.start": "开始配置",

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -1,0 +1,109 @@
+/**
+ * Provider registry — the single source of truth for all LLM providers.
+ *
+ * To add a new provider:
+ *   1. Add an entry to `providers` below (frontend metadata + fields).
+ *   2. Create `src-tauri/src/transcription/<id>.rs` (transcribe + polish).
+ *   3. Add a match arm in `commands.rs` → `transcribe_with_provider` / `polish_with_provider`.
+ *   That's it — no new IPC commands, no config schema changes.
+ */
+
+export interface ProviderField {
+  key: string;
+  label: string;
+  type: "text" | "password" | "select";
+  placeholder?: string;
+  options?: { value: string; label: string }[];
+  mono?: boolean;
+  /** If true, this field and the next `half` field share one row. */
+  half?: boolean;
+}
+
+export interface ProviderDef {
+  id: string;
+  name: string;
+  tagline: string;
+  icon: string; // SVG inner content for a 24×24 viewBox
+  fields: ProviderField[];
+  /** IPC command that returns boolean — called with `{ provider: id }` */
+  authCheck?: string;
+  authOkText?: string;
+  authFailText?: string;
+  /** HTML string shown below the config form */
+  hint?: string;
+}
+
+export const providers: ProviderDef[] = [
+  {
+    id: "groq",
+    name: "Groq",
+    tagline: "免费 API Key",
+    icon: '<path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>',
+    fields: [
+      {
+        key: "api_key",
+        label: "API Key",
+        type: "password",
+        placeholder: "gsk_...",
+      },
+    ],
+    hint: '在 <a href="https://console.groq.com" target="_blank" rel="noopener">console.groq.com</a> 免费获取',
+  },
+  {
+    id: "vertex_ai",
+    name: "Vertex AI",
+    tagline: "Google Cloud",
+    icon: '<path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/><polyline points="3.27 6.96 12 12.01 20.73 6.96" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/><line x1="12" y1="22.08" x2="12" y2="12" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>',
+    fields: [
+      {
+        key: "project_id",
+        label: "GCP 项目 ID",
+        type: "text",
+        placeholder: "my-project-id",
+      },
+      {
+        key: "location",
+        label: "区域",
+        type: "text",
+        placeholder: "us-central1",
+        mono: true,
+        half: true,
+      },
+      {
+        key: "model",
+        label: "模型",
+        type: "select",
+        half: true,
+        options: [
+          { value: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+          { value: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+          { value: "gemini-2.0-flash", label: "Gemini 2.0 Flash" },
+        ],
+      },
+    ],
+    authCheck: "check_provider_status",
+    authOkText: "gcloud 凭证已就绪",
+    authFailText: "未检测到 gcloud 凭证",
+    hint: '请运行 <code>gcloud auth application-default login</code>',
+  },
+];
+
+export function getProvider(id: string): ProviderDef | undefined {
+  return providers.find((p) => p.id === id);
+}
+
+/** Group fields so adjacent `half` fields share one row. */
+export function groupFields(fields: ProviderField[]): ProviderField[][] {
+  const groups: ProviderField[][] = [];
+  let i = 0;
+  while (i < fields.length) {
+    if (fields[i].half && i + 1 < fields.length && fields[i + 1].half) {
+      groups.push([fields[i], fields[i + 1]]);
+      i += 2;
+    } else {
+      groups.push([fields[i]]);
+      i += 1;
+    }
+  }
+  return groups;
+}

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -8,9 +8,11 @@
  *   That's it — no new IPC commands, no config schema changes.
  */
 
+import { type L, l } from "./i18n";
+
 export interface ProviderField {
   key: string;
-  label: string;
+  label: L;
   type: "text" | "password" | "select";
   placeholder?: string;
   options?: { value: string; label: string }[];
@@ -22,48 +24,51 @@ export interface ProviderField {
 export interface ProviderDef {
   id: string;
   name: string;
-  tagline: string;
+  tagline: L;
   icon: string; // SVG inner content for a 24×24 viewBox
   fields: ProviderField[];
   /** IPC command that returns boolean — called with `{ provider: id }` */
   authCheck?: string;
-  authOkText?: string;
-  authFailText?: string;
+  authOkText?: L;
+  authFailText?: L;
   /** HTML string shown below the config form */
-  hint?: string;
+  hint?: L;
 }
 
 export const providers: ProviderDef[] = [
   {
     id: "groq",
     name: "Groq",
-    tagline: "免费 API Key",
+    tagline: l("Free API Key", "免费 API Key"),
     icon: '<path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>',
     fields: [
       {
         key: "api_key",
-        label: "API Key",
+        label: l("API Key", "API Key"),
         type: "password",
         placeholder: "gsk_...",
       },
     ],
-    hint: '在 <a href="https://console.groq.com" target="_blank" rel="noopener">console.groq.com</a> 免费获取',
+    hint: l(
+      'Get one free at <a href="https://console.groq.com" target="_blank" rel="noopener">console.groq.com</a>',
+      '在 <a href="https://console.groq.com" target="_blank" rel="noopener">console.groq.com</a> 免费获取',
+    ),
   },
   {
     id: "vertex_ai",
     name: "Vertex AI",
-    tagline: "Google Cloud",
+    tagline: l("Google Cloud", "Google Cloud"),
     icon: '<path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/><polyline points="3.27 6.96 12 12.01 20.73 6.96" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/><line x1="12" y1="22.08" x2="12" y2="12" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>',
     fields: [
       {
         key: "project_id",
-        label: "GCP 项目 ID",
+        label: l("GCP Project ID", "GCP 项目 ID"),
         type: "text",
         placeholder: "my-project-id",
       },
       {
         key: "location",
-        label: "区域",
+        label: l("Region", "区域"),
         type: "text",
         placeholder: "us-central1",
         mono: true,
@@ -71,7 +76,7 @@ export const providers: ProviderDef[] = [
       },
       {
         key: "model",
-        label: "模型",
+        label: l("Model", "模型"),
         type: "select",
         half: true,
         options: [
@@ -82,9 +87,15 @@ export const providers: ProviderDef[] = [
       },
     ],
     authCheck: "check_provider_status",
-    authOkText: "gcloud 凭证已就绪",
-    authFailText: "未检测到 gcloud 凭证",
-    hint: '请运行 <code>gcloud auth application-default login</code>',
+    authOkText: l("gcloud credentials ready", "gcloud 凭证已就绪"),
+    authFailText: l(
+      "gcloud credentials not found",
+      "未检测到 gcloud 凭证",
+    ),
+    hint: l(
+      'Run <code>gcloud auth application-default login</code>',
+      '请运行 <code>gcloud auth application-default login</code>',
+    ),
   },
 ];
 


### PR DESCRIPTION
## Summary

This PR evolves Audio Input from a Groq-only app into a **multi-provider, multi-language** desktop tool (v0.3.5). Three major pillars:

### 1. Google Vertex AI Integration
- New `VertexClient` in Rust for Gemini-based audio transcription and text polishing
- Authenticates via **Application Default Credentials** (ADC) — no API key needed; reads `~/.config/gcloud/application_default_credentials.json` and performs OAuth refresh token exchange
- Supports vision-aware polishing (screenshot context → Gemini multimodal) with automatic retry and graceful degradation
- Model selector: Gemini 2.5 Flash, 2.5 Pro, 2.0 Flash

### 2. Extensible Provider Architecture
The codebase was refactored from hardcoded Groq logic to a **data-driven provider registry** pattern:

- **`providers.ts`** — single source of truth for provider metadata (name, icon, fields, auth checks). The UI renders dynamically from this registry; adding a new provider requires zero UI template changes
- **`config.rs`** — provider-specific settings stored in `HashMap<String, serde_json::Value>` instead of per-provider struct fields. Legacy `api_key` / `gcp_*` fields auto-migrate on first load
- **`commands.rs`** — 5 per-provider IPC commands replaced with 3 generic ones (`get_provider_config`, `save_provider_config`, `check_provider_status`). Transcription and polish dispatch via `transcribe_with_provider()` / `polish_with_provider()` match helpers

**To add a new provider (e.g., OpenAI) you only need:**
1. Add an entry to the `providers` array in `providers.ts`
2. Create `src-tauri/src/transcription/<id>.rs`
3. Add one match arm in each dispatch helper

No new IPC commands, no config schema changes, no UI template edits.

### 3. Internationalization (EN / 中文)
- **`i18n.ts`** — lightweight store-based i18n with `$t('key')` derived store, positional args, and `L` bilingual type for data definitions
- ~75 translation keys covering every user-facing string: Settings, Onboarding, HUD, Accessibility banner
- Language toggle in both the Onboarding welcome screen and the Settings panel
- Default is English; persisted to `localStorage`
- System tray menu switched to English (standard for macOS/Windows tray)

### Other Improvements
- **Window sizing** — Separate `ONBOARDING_W/H` and `SETTINGS_W/H` constants; onboarding window is wider (370×540) to fit provider config comfortably
- **Shortcut conflict handling** — `unregister_all()` before registering; emits `shortcut-conflict` event on failure → auto-opens Settings with a visible amber warning banner suggesting the user pick a different shortcut

## Changed Files

| Area | Files | What |
|------|-------|------|
| Vertex AI | `transcription/vertex.rs` (new), `transcription/mod.rs`, `transcription/polish.rs` | ADC auth, Gemini transcription + polish, vision fallback |
| Provider arch | `config.rs`, `commands.rs`, `lib.rs` | String-based provider, HashMap config, generic IPC, dispatch helpers |
| i18n | `i18n.ts` (new), `providers.ts` (new) | Translation store, bilingual provider registry |
| Frontend | `SettingsPanel.svelte`, `OnboardingFlow.svelte`, `App.svelte`, `RecordingIndicator.svelte` | Data-driven rendering, `$t()` throughout, language toggle |
| Tray | `tray.rs` | English menu labels |
| Version | `package.json`, `Cargo.toml`, `tauri.conf.json` | 0.2.0 → 0.3.5 |

**19 files changed, +1453 / −811 lines**

## Test Plan

- [ ] Fresh install: onboarding flow renders in English, language toggle switches to 中文 correctly
- [ ] Groq path: enter API key → record → transcribe → polish → inject (same as before)
- [ ] Vertex AI path: select Vertex AI → enter project ID → record → transcribe via Gemini → polish → inject
- [ ] Vertex AI ADC check: green badge when `gcloud auth application-default login` is configured, red when not
- [ ] Provider switch: switching between Groq ↔ Vertex AI persists config independently
- [ ] Shortcut conflict: if shortcut registration fails, amber banner appears in Settings
- [ ] Language persistence: pick 中文, restart app, UI stays in Chinese
- [ ] Legacy config migration: old config with top-level `api_key` / `gcp_project_id` auto-migrates to `provider_configs` HashMap
