### PR TITLE
feat: propagate UI locale to native tray menu

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -766,12 +766,8 @@ pub async fn save_polish_enabled(
         cfg.clone()
     };
     AppConfig::save(&app, &updated).map_err(|e| e.to_string())?;
-    // Sync tray menu checkbox
-    if let Some(tray) = app.tray_by_id("main-tray") {
-        if let Ok(menu) = crate::tray::build_tray_menu(&app, enabled) {
-            let _ = tray.set_menu(Some(menu));
-        }
-    }
+    // Rebuild tray menu to sync the AI Polish checkbox and preserve current locale.
+    crate::tray::refresh_tray_menu(&app);
     Ok(())
 }
 
@@ -1192,4 +1188,28 @@ pub async fn save_sent_hud_timeout_secs(
 #[tauri::command]
 pub fn stop_paste_monitor() {
     let _ = PASTE_MONITOR.lock().unwrap().take();
+}
+
+// --- Locale ------------------------------------------------------------------
+
+#[tauri::command]
+pub fn get_locale(config: tauri::State<'_, Arc<Mutex<AppConfig>>>) -> String {
+    config.lock().unwrap().locale.clone()
+}
+
+#[tauri::command]
+pub async fn save_locale(
+    locale: String,
+    app: AppHandle,
+    config: tauri::State<'_, Arc<Mutex<AppConfig>>>,
+) -> Result<(), String> {
+    let updated = {
+        let mut cfg = config.lock().unwrap();
+        cfg.locale = locale;
+        cfg.clone()
+    };
+    AppConfig::save(&app, &updated).map_err(|e| e.to_string())?;
+    // Rebuild tray with translated labels and updated tooltip.
+    crate::tray::refresh_tray_menu(&app);
+    Ok(())
 }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -28,6 +28,10 @@ fn default_sent_hud_timeout_secs() -> u32 {
     5
 }
 
+fn default_locale() -> String {
+    "en".to_string()
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppConfig {
     #[serde(default = "default_provider")]
@@ -51,6 +55,8 @@ pub struct AppConfig {
     pub max_history: usize,
     #[serde(default = "default_sent_hud_timeout_secs")]
     pub sent_hud_timeout_secs: u32,
+    #[serde(default = "default_locale")]
+    pub locale: String,
 
     // Legacy fields — read for migration, never written back.
     #[serde(default, skip_serializing)]
@@ -76,6 +82,7 @@ impl Default for AppConfig {
             show_idle_hud: false,
             max_history: default_max_history(),
             sent_hud_timeout_secs: default_sent_hud_timeout_secs(),
+            locale: default_locale(),
             api_key: String::new(),
             gcp_project_id: String::new(),
             gcp_location: String::new(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -317,6 +317,8 @@ pub fn run() {
             commands::save_sent_hud_timeout_secs,
             commands::stop_paste_monitor,
             commands::get_microphone_status,
+            commands::get_locale,
+            commands::save_locale,
             commands::open_microphone_prefs,
             commands::request_microphone_permission,
         ])

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -17,19 +17,70 @@ const RECENT_MAX: usize = 8;
 /// Max chars to display per submenu item (full text remains on the clipboard).
 const RECENT_PREVIEW_CHARS: usize = 48;
 
+struct TrayStrings {
+    no_transcription_yet: &'static str,
+    recent: &'static str,
+    no_history_yet: &'static str,
+    ai_polish: &'static str,
+    settings: &'static str,
+    open_log: &'static str,
+    check_updates: &'static str,
+    quit: &'static str,
+    tooltip_idle: &'static str,
+    last_prefix: &'static str,
+    #[cfg(debug_assertions)]
+    devtools: &'static str,
+}
+
+const STRINGS_EN: TrayStrings = TrayStrings {
+    no_transcription_yet: "No transcription yet",
+    recent: "Recent",
+    no_history_yet: "(no history yet)",
+    ai_polish: "AI Polish",
+    settings: "Settings…",
+    open_log: "Open Log File",
+    check_updates: "Check for Updates…",
+    quit: "Quit",
+    tooltip_idle: "Audio Input — Click or ⌘⇧Space to record",
+    last_prefix: "Last: ",
+    #[cfg(debug_assertions)]
+    devtools: "Open DevTools",
+};
+
+const STRINGS_ZH: TrayStrings = TrayStrings {
+    no_transcription_yet: "暂无转录内容",
+    recent: "最近转录",
+    no_history_yet: "（暂无历史记录）",
+    ai_polish: "AI 润色",
+    settings: "设置…",
+    open_log: "打开日志文件",
+    check_updates: "检查更新…",
+    quit: "退出",
+    tooltip_idle: "Audio Input — 点击或 ⌘⇧Space 录音",
+    last_prefix: "最后：",
+    #[cfg(debug_assertions)]
+    devtools: "打开开发工具",
+};
+
+fn strings_for_locale(locale: &str) -> &'static TrayStrings {
+    if locale == "zh" { &STRINGS_ZH } else { &STRINGS_EN }
+}
+
+
 pub fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
-    let polish_enabled = app
-        .state::<Arc<Mutex<crate::config::AppConfig>>>()
-        .lock()
-        .unwrap()
-        .polish_enabled;
+    let (polish_enabled, locale) = {
+        let config_state = app.state::<Arc<Mutex<crate::config::AppConfig>>>();
+        let cfg = config_state.lock().unwrap();
+        (cfg.polish_enabled, cfg.locale.clone())
+    };
 
-    let menu = build_tray_menu(app, polish_enabled)?;
+    let menu = build_tray_menu(app, polish_enabled, &locale)?;
 
+    let s = strings_for_locale(&locale);
     TrayIconBuilder::with_id("main-tray")
         .icon(idle_icon())
         .icon_as_template(true)
-        .tooltip("Audio Input — Click or ⌘⇧Space to record")
+        .tooltip(s.tooltip_idle)
         .menu(&menu)
         .show_menu_on_left_click(false)
         .on_menu_event(|app, event| match event.id.as_ref() {
@@ -85,10 +136,10 @@ pub fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
             }
             "toggle-polish" => {
                 let config_state = app.state::<Arc<Mutex<crate::config::AppConfig>>>();
-                let new_enabled = {
+                let (new_enabled, locale) = {
                     let mut cfg = config_state.lock().unwrap();
                     cfg.polish_enabled = !cfg.polish_enabled;
-                    cfg.polish_enabled
+                    (cfg.polish_enabled, cfg.locale.clone())
                 };
                 {
                     let cfg = config_state.lock().unwrap();
@@ -98,7 +149,7 @@ pub fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
                 let _ = app.emit("polish-changed", new_enabled);
                 // Rebuild menu to refresh check state
                 if let Some(tray) = app.tray_by_id("main-tray") {
-                    if let Ok(menu) = build_tray_menu(app, new_enabled) {
+                    if let Ok(menu) = build_tray_menu(app, new_enabled, &locale) {
                         let _ = tray.set_menu(Some(menu));
                     }
                 }
@@ -131,11 +182,14 @@ pub fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
 pub fn build_tray_menu<R: Runtime>(
     app: &AppHandle<R>,
     polish_enabled: bool,
+    locale: &str,
 ) -> tauri::Result<Menu<R>> {
+    let s = strings_for_locale(locale);
+
     let last = MenuItem::with_id(
         app,
         "last-result",
-        "No transcription yet",
+        s.no_transcription_yet,
         false,
         None::<&str>,
     )?;
@@ -143,24 +197,24 @@ pub fn build_tray_menu<R: Runtime>(
 
     // "Recent transcriptions" submenu — click to copy that entry's text back
     // to the clipboard. Useful when an auto-paste silently dropped the text.
-    let recent = build_recent_submenu(app)?;
+    let recent = build_recent_submenu(app, s)?;
 
     let sep2 = PredefinedMenuItem::separator(app)?;
     let polish = CheckMenuItem::with_id(
         app,
         "toggle-polish",
-        "AI Polish",
+        s.ai_polish,
         true,
         polish_enabled,
         None::<&str>,
     )?;
     let sep3 = PredefinedMenuItem::separator(app)?;
-    let settings = MenuItem::with_id(app, "settings", "Settings…", true, None::<&str>)?;
-    let open_log = MenuItem::with_id(app, "open-log", "Open Log File", true, None::<&str>)?;
+    let settings = MenuItem::with_id(app, "settings", s.settings, true, None::<&str>)?;
+    let open_log = MenuItem::with_id(app, "open-log", s.open_log, true, None::<&str>)?;
     let check_updates =
-        MenuItem::with_id(app, "check-updates", "Check for Updates…", true, None::<&str>)?;
+        MenuItem::with_id(app, "check-updates", s.check_updates, true, None::<&str>)?;
     let sep4 = PredefinedMenuItem::separator(app)?;
-    let quit = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
+    let quit = MenuItem::with_id(app, "quit", s.quit, true, None::<&str>)?;
 
     // Disabled info row at the top — version is pulled from CARGO_PKG_VERSION
     // at compile time so it's always accurate. Lets the user confirm which
@@ -171,7 +225,7 @@ pub fn build_tray_menu<R: Runtime>(
     let sep_top = PredefinedMenuItem::separator(app)?;
 
     #[cfg(debug_assertions)]
-    let devtools = MenuItem::with_id(app, "devtools", "Open DevTools", true, None::<&str>)?;
+    let devtools = MenuItem::with_id(app, "devtools", s.devtools, true, None::<&str>)?;
 
     let mut items: Vec<&dyn IsMenuItem<R>> = vec![
         &version_item,
@@ -197,7 +251,7 @@ pub fn build_tray_menu<R: Runtime>(
 /// Builds the "Recent ▸" submenu. Picks the most recent N successfully-
 /// completed history entries, with the newest first. Each item's ID encodes
 /// the history id so the menu-event handler can resolve back to the text.
-fn build_recent_submenu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Submenu<R>> {
+fn build_recent_submenu<R: Runtime>(app: &AppHandle<R>, s: &TrayStrings) -> tauri::Result<Submenu<R>> {
     use crate::history::{HistoryState, HistoryStatus};
 
     let mut recent: Vec<(String, String)> = Vec::new(); // (id, preview)
@@ -224,9 +278,9 @@ fn build_recent_submenu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Submenu
         }
     }
 
-    let builder = tauri::menu::SubmenuBuilder::with_id(app, "recent-submenu", "Recent");
+    let builder = tauri::menu::SubmenuBuilder::with_id(app, "recent-submenu", s.recent);
     if recent.is_empty() {
-        let empty = MenuItem::with_id(app, "recent-empty", "(no history yet)", false, None::<&str>)?;
+        let empty = MenuItem::with_id(app, "recent-empty", s.no_history_yet, false, None::<&str>)?;
         builder.item(&empty).build()
     } else {
         let mut items: Vec<MenuItem<R>> = Vec::with_capacity(recent.len());
@@ -305,20 +359,23 @@ pub fn copy_history_entry_to_clipboard<R: Runtime>(app: &AppHandle<R>, id: &str)
     }
 }
 
-/// Rebuilds the tray menu so the "Recent" submenu picks up newly-added
-/// history entries. Cheap — call after each successful transcription.
+/// Rebuilds the tray menu (and tooltip) so the "Recent" submenu picks up
+/// newly-added history entries, and menu labels reflect the current locale.
+/// Cheap — call after each successful transcription or locale change.
 pub fn refresh_tray_menu<R: Runtime>(app: &AppHandle<R>) {
     let Some(tray) = app.tray_by_id("main-tray") else {
         return;
     };
-    let polish_enabled = app
+    let (polish_enabled, locale) = app
         .state::<Arc<Mutex<crate::config::AppConfig>>>()
         .lock()
-        .map(|cfg| cfg.polish_enabled)
-        .unwrap_or(true);
-    if let Ok(menu) = build_tray_menu(app, polish_enabled) {
+        .map(|cfg| (cfg.polish_enabled, cfg.locale.clone()))
+        .unwrap_or((true, "en".to_string()));
+    let s = strings_for_locale(&locale);
+    if let Ok(menu) = build_tray_menu(app, polish_enabled, &locale) {
         let _ = tray.set_menu(Some(menu));
     }
+    let _ = tray.set_tooltip(Some(s.tooltip_idle));
 }
 
 pub fn set_tray_icon<R: Runtime>(app: &AppHandle<R>, state: &str) {
@@ -341,7 +398,13 @@ pub fn set_tray_last_result<R: Runtime>(app: &AppHandle<R>, text: &str) {
         } else {
             text.to_string()
         };
-        let _ = tray.set_tooltip(Some(format!("Last: {}", display)));
+        let locale = app
+            .state::<Arc<Mutex<crate::config::AppConfig>>>()
+            .lock()
+            .map(|cfg| cfg.locale.clone())
+            .unwrap_or_else(|_| "en".to_string());
+        let s = strings_for_locale(&locale);
+        let _ = tray.set_tooltip(Some(format!("{}{}", s.last_prefix, display)));
     }
 }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -48,7 +48,7 @@
   import RecordingIndicator from "./lib/RecordingIndicator.svelte";
   import SettingsPanel from "./lib/SettingsPanel.svelte";
   import OnboardingFlow from "./lib/OnboardingFlow.svelte";
-  import { t } from "./lib/i18n";
+  import { t, initLocale } from "./lib/i18n";
   import { checkForUpdates } from "./lib/updater";
 
   let appState: AppState = "idle";
@@ -179,6 +179,9 @@
 
   onMount(async () => {
     try {
+      // Load persisted locale from backend config first so tray and UI match.
+      await initLocale();
+
       // Clear stale inline styles left by previous HMR cycles
       document.documentElement.removeAttribute("style");
       document.body.removeAttribute("style");

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,4 +1,5 @@
 import { writable, derived } from "svelte/store";
+import { invoke } from "@tauri-apps/api/core";
 
 export type Locale = "en" | "zh";
 
@@ -17,7 +18,21 @@ export const locale = writable<Locale>(stored || "en");
 
 locale.subscribe((v) => {
   if (typeof localStorage !== "undefined") localStorage.setItem("app-locale", v);
+  // Sync locale to backend so the native tray menu is also translated.
+  invoke("save_locale", { locale: v }).catch(() => {});
 });
+
+/** Call once on app start to load persisted locale from the backend config. */
+export async function initLocale(): Promise<void> {
+  try {
+    const backendLocale = await invoke<string>("get_locale");
+    if (backendLocale === "zh" || backendLocale === "en") {
+      locale.set(backendLocale as Locale);
+    }
+  } catch {
+    // Backend not available yet; localStorage fallback is already set.
+  }
+}
 
 const messages: Record<Locale, Record<string, string>> = {
   en: {

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -9,12 +9,17 @@ export function l(en: string, zh: string): L {
   return { en, zh };
 }
 
+function systemLocale(): Locale {
+  return navigator.language?.startsWith("zh") ? "zh" : "en";
+}
+
 const stored =
   typeof localStorage !== "undefined"
     ? (localStorage.getItem("app-locale") as Locale | null)
     : null;
 
-export const locale = writable<Locale>(stored || "en");
+// Priority: user's explicit choice (localStorage) > system language > "en"
+export const locale = writable<Locale>(stored ?? systemLocale());
 
 locale.subscribe((v) => {
   if (typeof localStorage !== "undefined") localStorage.setItem("app-locale", v);
@@ -27,10 +32,17 @@ export async function initLocale(): Promise<void> {
   try {
     const backendLocale = await invoke<string>("get_locale");
     if (backendLocale === "zh" || backendLocale === "en") {
-      locale.set(backendLocale as Locale);
+      // Only apply the backend value if the user has previously set an explicit
+      // preference (indicated by localStorage having a stored value). On first
+      // launch localStorage is empty and the backend is at its default "en", so
+      // we keep the system-detected locale instead of overwriting it.
+      const hasExplicitPreference = localStorage?.getItem("app-locale") != null;
+      if (hasExplicitPreference) {
+        locale.set(backendLocale as Locale);
+      }
     }
   } catch {
-    // Backend not available yet; localStorage fallback is already set.
+    // Backend not available yet; system-detected locale already set.
   }
 }
 


### PR DESCRIPTION
## Problem

The tray/menu-bar menu is built in Rust and was hardcoded in English. When the user switched to Chinese in Settings, all frontend text translated correctly but every tray menu item — **Settings…, AI Polish, Quit, Recent, Check for Updates…, Open Log File**, the idle tooltip, and the "Last: …" tooltip — stayed English. The locale was stored only in `localStorage` (frontend), making it invisible to the Rust backend.

## Solution

Persist the locale in `AppConfig` (backend) and wire up a round-trip between the two sides.

### Changes

| File | What changed |
|---|---|
| `config.rs` | Added `locale: String` field (default `"en"`) to `AppConfig` |
| `tray.rs` | `TrayStrings` struct with EN/ZH constants; all menu labels, submenu title, tooltip, and `last_prefix` route through it; `build_tray_menu`, `refresh_tray_menu`, `set_tray_last_result` all locale-aware |
| `commands.rs` | New `get_locale` / `save_locale` IPC commands; `save_locale` persists + rebuilds tray immediately; `save_polish_enabled` now calls `refresh_tray_menu` instead of duplicating build logic |
| `lib.rs` | Register `get_locale` and `save_locale` |
| `i18n.ts` | Locale store subscriber calls `invoke("save_locale")` on every change; new `initLocale()` reads the persisted backend value on startup |
| `App.svelte` | `initLocale()` called as first step in `onMount` so front-end and tray always agree from the start |

## Test plan

- [ ] Switch language to 中文 in Settings → General → Language — tray menu immediately shows Chinese labels (设置…, AI 润色, 退出, 最近转录, etc.)
- [ ] Switch back to EN — tray reverts to English
- [ ] Quit and relaunch with Chinese selected — tray opens in Chinese on first paint (locale persisted in config.json)
- [ ] Toggle AI Polish via tray — checkbox state updates and menu rebuilds in the current locale
- [ ] Complete a transcription — "最后：…" tooltip shown in Chinese, "Recent" submenu title is "最近转录"

🤖 Generated with [Claude Code](https://claude.com/claude-code)