### PR TITLE
ci: automate release flow — PR-open auto-bump + RELEASE-commit trigger

### DIFF
--- a/.github/workflows/auto-bump-version.yml
+++ b/.github/workflows/auto-bump-version.yml
@@ -1,0 +1,120 @@
+name: Auto-bump version on release PRs
+
+# Runs when a PR is opened (or updated) targeting main, computes the next
+# version, runs scripts/bump-version.sh, and pushes a "RELEASE X.Y.Z" commit
+# to the PR's head branch. Removes the chance of forgetting the version bump
+# before tagging — see RELEASING.md for the full flow.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches: [main]
+
+# Cancel earlier in-flight runs for the same PR — only the latest decision
+# matters (labels can change, head can be force-pushed).
+concurrency:
+  group: auto-bump-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  bump:
+    # Skip PRs from forks — we can't push back to a fork's branch.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout PR head branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine next version
+        id: next
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          # Base version = whatever main currently ships. We bump from there
+          # rather than from the PR head, so re-running the workflow with a
+          # different label produces a stable, predictable next version.
+          git fetch origin main --quiet
+          BASE=$(git show origin/main:package.json | \
+            sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+          if [[ ! "$BASE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Could not parse base version from main: '$BASE'"
+            exit 1
+          fi
+          IFS='.' read -r MAJ MIN PAT <<< "$BASE"
+
+          # Bump rule, label-driven. Default is patch.
+          if echo "$LABELS" | grep -q '"release:major"'; then
+            NEXT="$((MAJ + 1)).0.0"
+            KIND="major"
+          elif echo "$LABELS" | grep -q '"release:minor"'; then
+            NEXT="${MAJ}.$((MIN + 1)).0"
+            KIND="minor"
+          else
+            NEXT="${MAJ}.${MIN}.$((PAT + 1))"
+            KIND="patch"
+          fi
+
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "kind=$KIND" >> "$GITHUB_OUTPUT"
+          echo "main version: $BASE   →   target ($KIND): $NEXT"
+
+      - name: Decide whether to bump / amend / skip
+        id: gate
+        run: |
+          LAST_MSG=$(git log -1 --pretty=%s)
+          TARGET="RELEASE ${{ steps.next.outputs.next }}"
+          if [[ "$LAST_MSG" == "$TARGET" ]]; then
+            echo "Head is already $TARGET — nothing to do."
+            echo "action=skip" >> "$GITHUB_OUTPUT"
+          elif [[ "$LAST_MSG" =~ ^RELEASE\ [0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            # Previous run produced a RELEASE commit for a different version
+            # (label changed, base moved, etc.). Amend in place so the PR
+            # history stays clean — one RELEASE commit, force-pushed.
+            echo "Head is a stale RELEASE commit — will amend to $TARGET."
+            echo "action=amend" >> "$GITHUB_OUTPUT"
+          else
+            echo "Head is a regular commit — will add a new RELEASE commit."
+            echo "action=new" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Node
+        if: steps.gate.outputs.action != 'skip'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup Rust
+        if: steps.gate.outputs.action != 'skip'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        if: steps.gate.outputs.action != 'skip'
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Run bump script
+        if: steps.gate.outputs.action != 'skip'
+        run: bash scripts/bump-version.sh "${{ steps.next.outputs.next }}"
+
+      - name: Commit and push to PR head
+        if: steps.gate.outputs.action != 'skip'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json
+          if [ "${{ steps.gate.outputs.action }}" = "amend" ]; then
+            git commit --amend -m "RELEASE ${{ steps.next.outputs.next }}"
+            git push --force-with-lease
+          else
+            git commit -m "RELEASE ${{ steps.next.outputs.next }}"
+            git push
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,15 @@ name: Release
 
 on:
   push:
-    tags:
-      # Strict semver only — prevents test tags like v0.4.5-test from triggering
-      # a production release + homebrew tap update.
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+    branches:
+      - main
 
 jobs:
   create-release:
+    # Only RELEASE commits ship a release. Everything else on main (docs, ci,
+    # follow-up fixes) merges silently. See RELEASING.md for the flow that
+    # generates these commits via the auto-bump-version workflow on PR open.
+    if: startsWith(github.event.head_commit.message, 'RELEASE ')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -21,65 +23,64 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify tag is on main
+      - name: Extract version from commit message
+        id: meta
         run: |
-          # A tag should only ship if its commit is reachable from main —
-          # otherwise we'd be shipping WIP from a feature branch. Fetch
-          # origin/main and confirm the tagged commit is an ancestor.
-          git fetch origin main --quiet
-          if ! git merge-base --is-ancestor "${GITHUB_SHA}" origin/main; then
-            echo "::error::Tag ${GITHUB_REF_NAME} (${GITHUB_SHA}) is not on main. Refusing to release. Merge to main and retag."
+          # Subject line must be exactly: RELEASE <semver>
+          # Strict regex — rejects "RELEASE 0.4.10-beta", "RELEASE  0.4.10"
+          # (double space), trailing chars, etc. Keeps the tag pattern strict
+          # the same way the old `tags: v[0-9]+.[0-9]+.[0-9]+` filter did.
+          MSG=$(git log -1 --pretty=%s)
+          if [[ ! "$MSG" =~ ^RELEASE\ ([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "::error::Commit message '$MSG' is not a strict 'RELEASE X.Y.Z' release commit."
             exit 1
           fi
-          echo "Tag commit is on main — proceeding."
+          VERSION="${BASH_REMATCH[1]}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Releasing version: $VERSION"
 
-      - name: Refuse if a release already exists for this tag
+      - name: Refuse if a release already exists for this version
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Catches the failure mode where someone went to the web UI
-          # and clicked "Draft a new release" with this tag. That creates
-          # the release object BEFORE the workflow runs, then our
-          # create-release step adds a SECOND release for the same tag —
-          # GitHub allows it, but artifacts then split across the two and
-          # update-cask downloads from the wrong one.
-          if gh release view "${GITHUB_REF_NAME}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            echo "::error::A release for ${GITHUB_REF_NAME} already exists. Did you use the web UI to create it? Only tag pushes should create releases. Delete the existing release and re-push the tag."
+          # Catches the case where v0.4.X was already released (perhaps a
+          # previous failed run that got recovered manually) but main got
+          # another "RELEASE 0.4.X" commit. Without this, we'd create a
+          # SECOND GitHub release for the same tag — artifacts split, the
+          # homebrew tap update looks at the wrong one. This is exactly how
+          # v0.4.11 broke historically.
+          TAG="v${{ steps.meta.outputs.version }}"
+          if gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "::error::A release for $TAG already exists. Bump to a new version (see RELEASING.md) or delete the existing release if it was a failed run."
             exit 1
           fi
-          echo "No pre-existing release for ${GITHUB_REF_NAME} — safe to proceed."
+          echo "No pre-existing release for $TAG — safe to proceed."
 
-      - name: Extract version
-        id: meta
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
-      - name: Verify source version matches tag
+      - name: Verify source files match commit-message version
         run: |
-          # If the tag is v0.5.0 but package.json / Cargo.toml / tauri.conf.json
-          # still say 0.4.x, the binary will be misbranded — internal version
-          # string says 0.4.x but tauri-action labels artifacts 0.5.0.
-          # Catches the case where someone tagged without running the
-          # version-bump commit from RELEASING.md.
-          TAG_V="${GITHUB_REF_NAME#v}"
-          # Allow grep-style match; jq would be cleaner but jq isn't on
-          # ubuntu-latest without setup. sed extracts the version field.
+          # Defense in depth: scripts/bump-version.sh and the auto-bump
+          # workflow should have already synced these. If somehow they're
+          # out of sync (manual commit that hand-edited the message?), the
+          # binary would be misbranded — internal version string says
+          # 0.4.x but tauri-action labels artifacts as 0.5.0.
+          REL_V="${{ steps.meta.outputs.version }}"
           PKG_V=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' package.json | head -1)
           CARGO_V=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' src-tauri/Cargo.toml | head -1)
           TAURI_V=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' src-tauri/tauri.conf.json | head -1)
-          echo "tag:                ${TAG_V}"
+          echo "commit-msg:         ${REL_V}"
           echo "package.json:       ${PKG_V}"
           echo "Cargo.toml:         ${CARGO_V}"
           echo "tauri.conf.json:    ${TAURI_V}"
           fail=0
-          [ "${TAG_V}" = "${PKG_V}" ] || { echo "::error::package.json version (${PKG_V}) does not match tag (${TAG_V})"; fail=1; }
-          [ "${TAG_V}" = "${CARGO_V}" ] || { echo "::error::Cargo.toml version (${CARGO_V}) does not match tag (${TAG_V})"; fail=1; }
-          [ "${TAG_V}" = "${TAURI_V}" ] || { echo "::error::tauri.conf.json version (${TAURI_V}) does not match tag (${TAG_V})"; fail=1; }
+          [ "${REL_V}" = "${PKG_V}" ]   || { echo "::error::package.json version (${PKG_V}) does not match commit-msg (${REL_V})"; fail=1; }
+          [ "${REL_V}" = "${CARGO_V}" ] || { echo "::error::Cargo.toml version (${CARGO_V}) does not match commit-msg (${REL_V})"; fail=1; }
+          [ "${REL_V}" = "${TAURI_V}" ] || { echo "::error::tauri.conf.json version (${TAURI_V}) does not match commit-msg (${REL_V})"; fail=1; }
           if [ "${fail}" -eq 1 ]; then
             echo ""
-            echo "::error::Bump the version in package.json + src-tauri/Cargo.toml + src-tauri/tauri.conf.json + commit, THEN tag — see RELEASING.md."
+            echo "::error::Run 'npm run release:bump ${REL_V}' and amend the commit — see RELEASING.md."
             exit 1
           fi
-          echo "All version fields match the tag — proceeding."
+          echo "All version fields match the commit-msg — proceeding."
 
       - name: Generate release notes
         id: notes
@@ -97,13 +98,22 @@ jobs:
       - name: Create draft release
         id: create
         uses: actions/github-script@v7
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
         with:
           script: |
+            const tag = `v${process.env.VERSION}`;
             const { data } = await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag_name: context.ref.replace('refs/tags/', ''),
-              name: `Audio Input ${context.ref.replace('refs/tags/', '')}`,
+              tag_name: tag,
+              name: `Audio Input ${tag}`,
+              // Pin the eventual tag to THIS commit, not whatever main's HEAD
+              // happens to be when the release is published. Without this,
+              // a follow-up commit landing on main mid-build would cause
+              // the tag to point at the wrong commit when update-cask
+              // flips draft → public.
+              target_commitish: context.sha,
               body: `${{ steps.notes.outputs.body }}`,
               draft: true,
             });
@@ -143,9 +153,12 @@ jobs:
       - name: Install JS dependencies
         run: npm ci
 
-      - name: Sync version from tag into tauri.conf.json
+      - name: Sync version into tauri.conf.json
         shell: bash
         run: |
+          # Defense in depth — create-release already verified that source
+          # files match the release version, but tauri-action reads from
+          # tauri.conf.json so any drift would mis-label artifacts.
           VERSION=${{ needs.create-release.outputs.version }}
           sed -i.bak "s/\"version\": \".*\"/\"version\": \"${VERSION}\"/" src-tauri/tauri.conf.json
 
@@ -243,9 +256,12 @@ jobs:
       - name: Install JS dependencies
         run: npm ci
 
-      - name: Sync version from tag into tauri.conf.json
+      - name: Sync version into tauri.conf.json
         shell: bash
         run: |
+          # Defense in depth — create-release already verified that source
+          # files match the release version, but tauri-action reads from
+          # tauri.conf.json so any drift would mis-label artifacts.
           VERSION=${{ needs.create-release.outputs.version }}
           sed -i.bak "s/\"version\": \".*\"/\"version\": \"${VERSION}\"/" src-tauri/tauri.conf.json
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -97,10 +97,18 @@ What happens automatically when the PR opens:
 
 ```bash
 # 2. Review the PR (including the auto-added RELEASE commit). Merge it.
-#    Merge must be FAST-FORWARD — set the repo's PR merge style to "Rebase
-#    and merge" or use `gh pr merge --rebase` so main's history stays linear.
+#    Merge MUST preserve the `RELEASE X.Y.Z` commit subject on main.
 gh pr merge <pr-number> --rebase --delete-branch=false
 ```
+
+> ⚠️ **Use "Rebase and merge" only.** "Squash and merge" rewrites the
+> commit subject to the PR title (default: `Release X.Y.Z (#N)` — note
+> the case + parens), and "Create a merge commit" produces a `Merge
+> pull request #N ...` subject. Both silently break the `release.yml`
+> trigger — the workflow skips, no error surfaces, no release ships.
+> The safest fix is to disable squash + merge-commit in the repo
+> settings (Settings → General → Pull Requests) so only rebase is
+> available.
 
 The push to `main` triggers `release.yml` because the head commit is `RELEASE X.Y.Z`. The workflow:
 
@@ -156,19 +164,27 @@ What's already happened by the time a failure surfaces:
 - `build-macos` / `build-windows` may have uploaded some artifacts to the draft
 - `update-cask` not yet → release not published, Homebrew tap NOT updated, **no `vX.Y.Z` tag exists in git**
 
-Clean up:
+Clean up — **prefer the forward path** (bump to the next patch + new RELEASE commit). Force-pushing `main` rewrites shared history; reserve it for the rare case where the failure is genuinely transient (e.g. notarytool flake) AND no one else has pulled the broken commit yet.
+
 ```bash
-# Delete the draft release. No tag exists yet (the publish step is what creates
-# the tag), so --cleanup-tag is a no-op but harmless to include.
+# 1. Delete the draft release. No tag exists yet (the publish step creates
+#    the tag), so --cleanup-tag is a no-op here but harmless to include.
 gh release delete v0.4.X --yes --cleanup-tag
 
-# Then either re-trigger by pushing a no-op commit to main (won't release —
-# subject must be "RELEASE X.Y.Z"), or amend the RELEASE commit and push again:
-git commit --amend --no-edit
-git push --force-with-lease origin main
+# 2. Forward path (default): land a NEW RELEASE commit for the next patch.
+#    No history rewriting; safe for shared branches.
+npm run release:bump 0.4.Y         # Y = X + 1
+git commit -am "RELEASE 0.4.Y"
+git push origin main               # release.yml fires fresh
+
+# Escape hatch (only for genuinely transient infra failures): re-trigger
+# the same version by force-pushing an amended HEAD. Rewrites main's tip —
+# coordinate with anyone else on the team first.
+#   git commit --amend --no-edit
+#   git push --force-with-lease origin main
 ```
 
-If the failure was AFTER publish (update-cask failed), the tag DOES exist. Use `gh release delete v0.4.X --yes --cleanup-tag` to drop both, then retry from a fresh RELEASE commit (bump the patch).
+If the failure was AFTER publish (update-cask failed), the `vX.Y.Z` tag DOES exist. Use `gh release delete v0.4.X --yes --cleanup-tag` to drop both the release and the tag, then take the forward path above.
 
 If `update-cask` runs but with a bad sha (e.g., a sed bug in the workflow), patch the cask manually in `tyun08/homebrew-tap` to unblock brew users while you fix the workflow.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-How code lands in users' hands. **Read this before tagging anything.**
+How code lands in users' hands. **Read this before tagging anything.** For the *why* behind the flow (trigger choice, token semantics, alternatives considered), see [`docs/release-flow-decisions.md`](docs/release-flow-decisions.md).
 
 ## Branches
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -79,67 +79,96 @@ Test-release runs **never** touch the Homebrew tap and **never** publish to GitH
 > looks at the wrong one. This is exactly how v0.4.11 broke. The workflow
 > now fails fast if a release already exists for the tag — don't bypass it.
 
-Once `development` is verified:
+Once `development` is verified, the release is two human actions: open the PR, then merge it. Version-bumping, tagging, building, publishing, and tap-updating all happen in CI.
 
 ```bash
-# 1. Merge to main
-git checkout main
-git pull
-git merge --ff-only development   # fast-forward only — no merge commits on main
-git push origin main
+# 1. Open a PR from development → main.
+gh pr create --base main --head development --title "Release X.Y.Z" --body ""
+# (Or use the GitHub web UI.)
+```
 
-# 2. Bump version in 3 files: package.json, src-tauri/Cargo.toml, src-tauri/tauri.conf.json
-# Make sure all three match. Then refresh Cargo.lock:
-( cd src-tauri && cargo build --quiet )
+What happens automatically when the PR opens:
 
-# 3. Commit + tag + push
-git add package.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json
-git commit -m "RELEASE 0.4.X"
-git push origin main
-git tag -a v0.4.X -m "Release 0.4.X"
-git push origin v0.4.X
+- The `auto-bump-version` workflow reads the current version on `main`, decides the next version, runs `scripts/bump-version.sh`, and pushes a `RELEASE X.Y.Z` commit to the head of `development`. The PR now has that commit on top.
+- Default bump is **patch** (`0.4.11 → 0.4.12`). To change the bump kind, add a label to the PR:
+  - `release:minor` → `0.4.11 → 0.5.0`
+  - `release:major` → `0.4.11 → 1.0.0`
+  - Changing the label re-runs the workflow and amends the bump commit.
 
-# 4. CRITICAL: sync development back to main so the next round of dev
-#    work doesn't diverge. Without this, your next merge --ff-only will
-#    fail because main has the RELEASE commit that development lacks.
+```bash
+# 2. Review the PR (including the auto-added RELEASE commit). Merge it.
+#    Merge must be FAST-FORWARD — set the repo's PR merge style to "Rebase
+#    and merge" or use `gh pr merge --rebase` so main's history stays linear.
+gh pr merge <pr-number> --rebase --delete-branch=false
+```
+
+The push to `main` triggers `release.yml` because the head commit is `RELEASE X.Y.Z`. The workflow:
+
+1. Extracts the version from the commit message
+2. Verifies source files (package.json / Cargo.toml / tauri.conf.json) all agree on that version
+3. Creates a draft GitHub release pinned to that commit via `target_commitish`
+4. Builds + signs + notarizes macOS arm/x86_64 (Developer ID: Jingtao Yun / V8RQ99X6H4)
+5. Builds + bundles Windows MSI + NSIS (WiX installed via choco)
+6. Generates `latest.json` (updater manifest) and uploads it to the release
+7. Publishes the release — **this is when the `vX.Y.Z` tag is actually created**, pointing at the RELEASE commit
+8. Updates the Homebrew tap (`tyun08/homebrew-tap` → `Casks/audio-input.rb`) with new URLs + SHA256s
+
+```bash
+# 3. CRITICAL: sync development back to main so the next round of dev
+#    work doesn't diverge. (The PR merge already updated main; this just
+#    pulls main's RELEASE commit back into development.)
 git checkout development
-git merge --ff-only main
+git pull --ff-only origin main
 git push origin development
 ```
 
-The push of `v0.4.X` triggers `release.yml`, which:
-
-1. Creates a draft GitHub release
-2. Builds + signs + notarizes macOS arm/x86_64 (Developer ID: Jingtao Yun / V8RQ99X6H4)
-3. Builds + bundles Windows MSI + NSIS (WiX installed via choco)
-4. Generates `latest.json` (updater manifest) and uploads to the release
-5. Publishes the release (lifts the draft flag)
-6. Updates the Homebrew tap (`tyun08/homebrew-tap` → `Casks/audio-input.rb`) with new URLs + SHA256s
-
 Pipeline takes ~15 min. Watch via `gh run watch <id>`.
 
-## Tag pattern is strict
+### Manual / emergency release
 
-`release.yml` only fires for tags matching `v[0-9]+.[0-9]+.[0-9]+` (strict semver, three parts, no suffix). So `v0.4.9-beta`, `v0.4.9-rc1`, `testbuild-anything` all do **not** trigger the production pipeline. That's the safety net — accidentally tagged WIP won't ship.
+If the auto-bump workflow is broken, you can still ship by hand:
+
+```bash
+git checkout main && git pull
+git merge --ff-only development
+npm run release:bump 0.4.X
+git add package.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json
+git commit -m "RELEASE 0.4.X"
+git push origin main           # triggers release.yml the same way
+```
+
+Same flow, just done locally instead of via the PR workflow.
+
+## What triggers a release
+
+`release.yml` runs on every push to `main`, but the job is gated by:
+
+```yaml
+if: startsWith(github.event.head_commit.message, 'RELEASE ')
+```
+
+So only commits whose subject is `RELEASE X.Y.Z` cut a release. Anything else (docs, CI, content) merges to `main` silently. The version is parsed out of the commit message; if it doesn't match strict semver (`MAJOR.MINOR.PATCH`) the workflow fails fast. This replaces the old "push a `vX.Y.Z` tag" trigger.
 
 ## If the pipeline fails mid-release
 
 What's already happened by the time a failure surfaces:
-- `create-release` succeeded → there's a draft release for the tag
-- `build-macos` / `build-windows` may have uploaded some artifacts
-- `update-cask` not yet → Homebrew tap NOT updated
+- `create-release` succeeded → there's a draft release object for `vX.Y.Z` (no git tag yet — the tag is only created on publish)
+- `build-macos` / `build-windows` may have uploaded some artifacts to the draft
+- `update-cask` not yet → release not published, Homebrew tap NOT updated, **no `vX.Y.Z` tag exists in git**
 
 Clean up:
 ```bash
-# Delete the draft release + tag
+# Delete the draft release. No tag exists yet (the publish step is what creates
+# the tag), so --cleanup-tag is a no-op but harmless to include.
 gh release delete v0.4.X --yes --cleanup-tag
 
-# Or, if the tag was on the wrong commit, delete + retag
-git push origin :refs/tags/v0.4.X
-git tag -d v0.4.X
-git tag -a v0.4.X -m "Release 0.4.X"   # ON THE RIGHT COMMIT
-git push origin v0.4.X
+# Then either re-trigger by pushing a no-op commit to main (won't release —
+# subject must be "RELEASE X.Y.Z"), or amend the RELEASE commit and push again:
+git commit --amend --no-edit
+git push --force-with-lease origin main
 ```
+
+If the failure was AFTER publish (update-cask failed), the tag DOES exist. Use `gh release delete v0.4.X --yes --cleanup-tag` to drop both, then retry from a fresh RELEASE commit (bump the patch).
 
 If `update-cask` runs but with a bad sha (e.g., a sed bug in the workflow), patch the cask manually in `tyun08/homebrew-tap` to unblock brew users while you fix the workflow.
 

--- a/docs/release-flow-decisions.md
+++ b/docs/release-flow-decisions.md
@@ -74,6 +74,24 @@ These are two **independent** issues that look related but aren't:
 
 In the chosen design, **nothing pushes a tag** — the tag is created by GitHub's REST API when the release is published. The trigger is the commit push, not a tag push, so these distinctions don't apply.
 
+### Side effect of using `GITHUB_TOKEN` for the bump push
+
+The `auto-bump-version` workflow uses `secrets.GITHUB_TOKEN` to push the `RELEASE X.Y.Z` commit to the PR's head branch. The same anti-recursion rule that blocks tag pushes from triggering workflows **also blocks commit pushes from triggering PR-level workflows** (tests, lint, typecheck on `pull_request: synchronize`). The diff is mechanical — a version-string edit and a Cargo.lock entry — so leaving it un-tested is acceptable today. **A future check that depends on the bump commit being CI-validated would silently miss it.** If that becomes a real concern, switch the auto-bump workflow to a PAT (or a GitHub App) and the synchronize event will fire normally.
+
+## Known failure modes
+
+### Squash-merge / merge-commit silently breaks the trigger
+
+`release.yml`'s gate is `startsWith(github.event.head_commit.message, 'RELEASE ')`. "Squash and merge" sets the head commit subject to the PR title (default `Release X.Y.Z (#N)` — lowercase `Release`, parens around the PR number), and "Create a merge commit" sets it to `Merge pull request #N ...`. Both **silently** skip the workflow — no error, no release. **Mitigation: disable squash + merge-commit at the repo level** (Settings → General → Pull Requests), leaving only "Rebase and merge" available. `RELEASING.md` calls this out, but enforcement at the settings layer is the real fix.
+
+### Two release PRs open at once
+
+Both `auto-bump-version` runs compute `NEXT` against `origin/main`, so they produce the same target version. First PR to merge releases `0.4.12` cleanly. Second PR's head still carries `RELEASE 0.4.12`; merging it fires `release.yml`, which fails at the "Refuse if a release already exists" guard. The error message is accurate but not helpful for diagnosis. **Recovery**: on the still-open PR, push any new commit (or close/reopen) — `auto-bump-version` re-runs against the new `origin/main`, bumps to `0.4.13`, amends. Then merge as normal.
+
+### Cargo.lock drift mid-build
+
+`release.yml`'s "Verify source files match commit-message version" step checks `Cargo.toml` but **not** `Cargo.lock`. If a contributor manually bumped `Cargo.toml` without running `cargo update --workspace`, Cargo.lock's `audio-input` entry would be stale; `tauri-action`'s build would either silently update Cargo.lock (producing an undeclared file change in CI) or fail. `scripts/bump-version.sh` post-bump verification catches this for the auto-bump path; manual edits are still vulnerable.
+
 ## Key files
 
 | File | Purpose |

--- a/docs/release-flow-decisions.md
+++ b/docs/release-flow-decisions.md
@@ -1,0 +1,129 @@
+# Release Flow — Architecture & Decisions
+
+Companion doc to [`RELEASING.md`](../RELEASING.md). `RELEASING.md` tells you **what to do**; this doc tells you **why it's shaped this way** so future-you (or a contributor) doesn't redesign it by accident.
+
+## Final architecture
+
+```
+human: open PR development → main                       (step 1 of 2)
+  │
+  ▼
+.github/workflows/auto-bump-version.yml
+  │  - computes next version (patch / minor / major from labels)
+  │  - runs scripts/bump-version.sh (edits 3 files + Cargo.lock)
+  │  - pushes "RELEASE X.Y.Z" commit to PR head (uses GITHUB_TOKEN)
+  ▼
+human: merge PR                                          (step 2 of 2)
+  │
+  ▼
+push to main triggers .github/workflows/release.yml
+  │  - job-level `if: startsWith(head_commit.message, 'RELEASE ')`
+  │    → non-release commits skip instantly (no runner, no rebuild)
+  │  - extract version from commit message (strict semver regex)
+  │  - verify the 3 source files agree with the commit-msg version
+  │  - create a draft GitHub release, target_commitish pinned to the
+  │    RELEASE commit (so the eventual tag lands on the right commit
+  │    even if main moves mid-build)
+  │  - build + sign + notarize (macOS arm + x64, Windows MSI + NSIS)
+  │  - upload latest.json (updater manifest)
+  │  - publish the release → GitHub creates the vX.Y.Z tag at this point
+  │  - update the homebrew tap
+  ▼
+done
+```
+
+Two human actions, zero terminal commands required after the PR opens.
+
+## Trigger trade-offs (decision record)
+
+| Option | Chosen? | Why / why not |
+|---|---|---|
+| Tag push triggers + human pushes tag from terminal | ❌ | One extra manual step after merge. The whole point was to remove manual steps. |
+| Tag push triggers + CI auto-pushes tag | ❌ | A CI-pushed tag using `GITHUB_TOKEN` does **not** trigger other workflows (GitHub anti-recursion). Would require a PAT secret. Not worth the secret-management overhead for a single-maintainer project. |
+| **Push to main triggers + commit-message gate** | ✅ | Fully automated, zero PAT needed. Cost: non-release pushes to main show a "Skipped" row in the Actions tab — no runner allocated, no compute spent, just one log row. |
+| UI Release Tab (Draft a new release button) | ❌ | This is what broke v0.4.11. The UI creates a release object *and* pushes the tag; the tag push triggers `release.yml`, which creates a **second** release object for the same tag. Artifacts split across the two. Commit `ae8be71` added an explicit `gh release view` guard that refuses to run if a release already exists for the tag. |
+
+## Concepts that confused us along the way
+
+These are two **independent** issues that look related but aren't:
+
+### Issue A — duplicate-release bug (v0.4.11)
+
+- **Cause**: UI Release Tab creates a release object *before* `release.yml` runs. The workflow's `create-release` step doesn't know one already exists, so it creates a second one.
+- **Has nothing to do with token type.** Even with a PAT, the duplicate would happen.
+- **Fix**: don't use the UI; let only `release.yml` create releases. (Plus the `ae8be71` guard catches the case explicitly.)
+
+### Issue B — `GITHUB_TOKEN` push doesn't trigger workflows
+
+- **Cause**: GitHub's anti-recursion protection. If workflow A uses the default `secrets.GITHUB_TOKEN` to push a tag, that tag push **does not** trigger workflow B.
+- **Has nothing to do with duplicate release.** It's purely about CI-to-CI chaining.
+- **Workarounds when you need CI-pushed tags to trigger other workflows**:
+  - Use a PAT (personal access token) instead of `GITHUB_TOKEN`
+  - Use a GitHub App
+  - Restructure so you don't need CI-to-CI chaining (← what we did)
+
+### Who can push a tag and have it trigger `release.yml`?
+
+| Pusher | Token / mechanism | Triggers workflows? |
+|---|---|---|
+| Human in terminal `git push origin v0.4.X` | personal credentials | ✅ |
+| GitHub UI "Create release" / "Create tag" | GitHub's own infra | ✅ (but UI release path has issue A) |
+| CI workflow using `secrets.GITHUB_TOKEN` | default token | ❌ |
+| CI workflow using a PAT | personal access token | ✅ |
+| CI workflow using a GitHub App | app installation token | ✅ |
+
+In the chosen design, **nothing pushes a tag** — the tag is created by GitHub's REST API when the release is published. The trigger is the commit push, not a tag push, so these distinctions don't apply.
+
+## Key files
+
+| File | Purpose |
+|---|---|
+| `scripts/bump-version.sh` | Edits `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, refreshes `Cargo.lock`. Single source of truth for "bump the version in N places." Exposed as `npm run release:bump X.Y.Z` for manual use. |
+| `.github/workflows/auto-bump-version.yml` | Triggers on PR open / sync / label change targeting `main`. Pushes (or amends) a `RELEASE X.Y.Z` commit to the PR's head branch. |
+| `.github/workflows/release.yml` | Triggers on push to `main`. Gated by `startsWith(head_commit.message, 'RELEASE ')`. Does the full build → publish → tap-update pipeline. |
+| `RELEASING.md` | Operator-facing flow doc — what to do when shipping. |
+| This file | Decision record — why the flow is shaped this way. |
+
+## Daily-use cheatsheet
+
+**Normal release**:
+
+```bash
+gh pr create --base main --head development --title "Release"
+# auto-bump-version posts the RELEASE commit to the PR within ~1 min
+# (default: patch bump; add label `release:minor` or `release:major` to override)
+gh pr merge <pr-number> --rebase
+# release.yml fires on the push to main; watch with `gh run watch`
+```
+
+**Manual / emergency release** (auto-bump workflow broken, network down, etc.):
+
+```bash
+git checkout main && git pull
+git merge --ff-only development
+npm run release:bump 0.4.X
+git commit -am "RELEASE 0.4.X"
+git push origin main          # release.yml fires the same way
+```
+
+Both paths produce the same `RELEASE X.Y.Z` commit on main; `release.yml` doesn't care which created it.
+
+## Validation after PR #86 merges
+
+Things to verify before relying on the new flow for a real release:
+
+- Open a throwaway PR `development → main`; confirm `auto-bump-version` adds a `RELEASE X.Y.Z` commit within ~1 minute
+- Add `release:minor` label, confirm the bump amends from patch to minor
+- Add `release:major`, confirm the bump amends again
+- Close the throwaway PR without merging
+- For the next real release, watch the full pipeline; confirm `vX.Y.Z` tag points at the `RELEASE X.Y.Z` commit and the homebrew tap got the right SHAs
+
+## Future upgrade paths
+
+If the project outgrows the hand-rolled flow:
+
+- **[release-please](https://github.com/googleapis/release-please-action)** (Google) — Reads conventional commits, opens a "release PR" with changelog + version bump. Used by Kubernetes, Node.js, Cloud Native projects. Needs a PAT or GitHub App.
+- **[changesets](https://github.com/changesets/changesets)** — Contributors add changeset files to PRs; bot collects them into a "version PR." Used by Tauri itself, Astro, tRPC, Remix. Needs a PAT.
+- **[semantic-release](https://github.com/semantic-release/semantic-release)** — Determines version + publishes on every push. Most aggressive automation. Heavy npm-ecosystem flavor.
+
+Trigger to switch: contributor count grows / release cadence ≥ weekly / changelog automation becomes a chore.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "tauri": "tauri",
+    "release:bump": "bash scripts/bump-version.sh",
     "test": "vitest run",
     "test:e2e": "playwright test",
     "lint": "eslint src",

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -42,16 +42,51 @@ CUR_TAURI=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$
 echo "current: package.json=$CUR_PKG  Cargo.toml=$CUR_CARGO  tauri.conf.json=$CUR_TAURI"
 echo "target:  $NEW"
 
-# Use perl for portable in-place edits (BSD sed on macOS vs GNU sed differ).
-# `unless $done++` limits the substitution to the first match only — both JSON
-# files have many "version" keys (dependencies etc); only the top-level one
-# should change.
-perl -i -pe 's/"version"\s*:\s*"[^"]+"/"version": "'"$NEW"'"/ unless $done++' "$PKG"
-perl -i -pe 's/"version"\s*:\s*"[^"]+"/"version": "'"$NEW"'"/ unless $done++' "$TAURI"
-perl -i -pe 's/^version\s*=\s*"[^"]+"/version = "'"$NEW"'"/ unless $done++' "$CARGO"
+# JSON files: slurp the whole file (`-0777`) and replace the FIRST `"version":
+# "..."` occurrence. Slurp mode is needed because the previous line-by-line
+# approach using `unless $done++` was buggy — `$done` was incremented on every
+# line including non-matches, so the substitution was skipped before it could
+# ever fire. Slurp + bare s/// (no /g) reliably hits the first match.
+#
+# Positional caveat: this assumes the top-level `version` is the file's first
+# `"version"` occurrence. True today for package.json and tauri.conf.json. A
+# nested `"version"` introduced ABOVE the top-level field (uncommon but
+# possible in tauri.conf.json plugin blocks) would be hit instead. JSON-aware
+# parsing would be sturdier — tracked as a fast-follow.
+perl -i -0777 -pe 's/"version"\s*:\s*"[^"]+"/"version": "'"$NEW"'"/' "$PKG"
+perl -i -0777 -pe 's/"version"\s*:\s*"[^"]+"/"version": "'"$NEW"'"/' "$TAURI"
+
+# Cargo.toml: anchor on the [package] section so we never hit a dependency's
+# version pin. Match the `version = "..."` line that lives between the
+# `[package]` header and the next `[section]` header.
+perl -i -0777 -pe '
+  s/(\[package\][^\[]*?\nversion\s*=\s*")[^"]+(")/${1}'"$NEW"'${2}/s
+' "$CARGO"
 
 # Refresh Cargo.lock — workspace package version is recorded there too.
-( cd src-tauri && cargo build --quiet )
+# `cargo update --workspace --offline` only rewrites the lockfile (no network,
+# no compile) and finishes in seconds; `cargo build` would re-validate the
+# whole dep graph which is overkill for a version-string bump.
+( cd src-tauri && cargo update --workspace --offline )
+
+# Sanity-check: confirm every file now reports the target version. Cheap
+# protection against future regressions in the edit logic above (the previous
+# version of this script silently produced no edits at all).
+POST_PKG=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$PKG" | head -1)
+POST_CARGO=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$CARGO" | head -1)
+POST_TAURI=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$TAURI" | head -1)
+POST_LOCK=$(awk '/name = "audio-input"/ { getline; print; exit }' src-tauri/Cargo.lock \
+  | sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p')
+
+fail=0
+[ "$POST_PKG"   = "$NEW" ] || { echo "::error::package.json post-bump = $POST_PKG (expected $NEW)" >&2; fail=1; }
+[ "$POST_CARGO" = "$NEW" ] || { echo "::error::Cargo.toml post-bump = $POST_CARGO (expected $NEW)" >&2; fail=1; }
+[ "$POST_TAURI" = "$NEW" ] || { echo "::error::tauri.conf.json post-bump = $POST_TAURI (expected $NEW)" >&2; fail=1; }
+[ "$POST_LOCK"  = "$NEW" ] || { echo "::error::Cargo.lock audio-input post-bump = $POST_LOCK (expected $NEW)" >&2; fail=1; }
+if [ "$fail" -eq 1 ]; then
+  echo "::error::version bump did not land in all files — see diff above and check the edit logic" >&2
+  exit 1
+fi
 
 echo
 echo "bumped to $NEW. files changed:"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Bump the version in all three places that must stay in sync:
+#   - package.json
+#   - src-tauri/Cargo.toml
+#   - src-tauri/tauri.conf.json
+# Then refresh Cargo.lock so the workspace builds cleanly.
+#
+# Usage: scripts/bump-version.sh 0.4.12
+#
+# Does NOT commit, tag, or push — release flow stays in RELEASING.md.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <new-version>   e.g. $0 0.4.12" >&2
+  exit 2
+fi
+
+NEW="$1"
+
+if [[ ! "$NEW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "error: version must be MAJOR.MINOR.PATCH (got: $NEW)" >&2
+  exit 2
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+PKG="package.json"
+CARGO="src-tauri/Cargo.toml"
+TAURI="src-tauri/tauri.conf.json"
+
+for f in "$PKG" "$CARGO" "$TAURI"; do
+  [[ -f "$f" ]] || { echo "error: $f not found" >&2; exit 1; }
+done
+
+# Extract current versions (same patterns release.yml uses for verification).
+CUR_PKG=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$PKG" | head -1)
+CUR_CARGO=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$CARGO" | head -1)
+CUR_TAURI=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$TAURI" | head -1)
+
+echo "current: package.json=$CUR_PKG  Cargo.toml=$CUR_CARGO  tauri.conf.json=$CUR_TAURI"
+echo "target:  $NEW"
+
+# Use perl for portable in-place edits (BSD sed on macOS vs GNU sed differ).
+# `unless $done++` limits the substitution to the first match only — both JSON
+# files have many "version" keys (dependencies etc); only the top-level one
+# should change.
+perl -i -pe 's/"version"\s*:\s*"[^"]+"/"version": "'"$NEW"'"/ unless $done++' "$PKG"
+perl -i -pe 's/"version"\s*:\s*"[^"]+"/"version": "'"$NEW"'"/ unless $done++' "$TAURI"
+perl -i -pe 's/^version\s*=\s*"[^"]+"/version = "'"$NEW"'"/ unless $done++' "$CARGO"
+
+# Refresh Cargo.lock — workspace package version is recorded there too.
+( cd src-tauri && cargo build --quiet )
+
+echo
+echo "bumped to $NEW. files changed:"
+git --no-pager diff --stat "$PKG" "$CARGO" "src-tauri/Cargo.lock" "$TAURI"


### PR DESCRIPTION
## Summary

- Two-step release: open PR (`development → main`), merge it. CI does the rest.
- New `auto-bump-version` workflow runs on PRs to main, pushes a `RELEASE X.Y.Z` commit to the PR head. Default patch bump; `release:minor` / `release:major` labels override.
- `release.yml` trigger flipped from tag push to push:main, gated on `head_commit.message` starting with `RELEASE `. Tag is created when the GitHub release is published, pinned to the RELEASE commit via `target_commitish`.
- `scripts/bump-version.sh` (exposed as `npm run release:bump X.Y.Z`) is the single source of truth for the 3-file version bump + Cargo.lock refresh. Used by the workflow and as the manual/emergency fallback.

## Why

`v0.4.11` shipped with `0.4.10` in its `Info.plist` because the tag was pushed without the bump commit. The previous fix (`ae8be71`) added a CI verification step but the bump itself was still manual. This eliminates the manual step entirely.

## Test plan

Hard to fully test pre-merge because the bump workflow only fires on PRs to `main`. Suggested validation after this merges to `development`:

- [ ] Open a throwaway PR `development → main` to confirm `auto-bump-version` adds a `RELEASE X.Y.Z` commit on top
- [ ] Add `release:minor` label, confirm the workflow amends the bump to a minor version
- [ ] Add `release:major` label, confirm same for major
- [ ] Close the throwaway PR without merging (don't actually ship)
- [ ] For the next real release, follow the new flow in `RELEASING.md` end-to-end (open PR, merge, watch `release.yml` complete)
- [ ] Verify the resulting \`vX.Y.Z\` tag points at the \`RELEASE X.Y.Z\` commit and the homebrew tap got the right SHAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)