### PR TITLE
fix: stop recording stream via pause() to prevent zombie cpal streams

### DIFF
--- a/src-tauri/src/audio/recorder.rs
+++ b/src-tauri/src/audio/recorder.rs
@@ -5,9 +5,9 @@ use std::sync::{Arc, Mutex};
 use tauri::{Manager, Runtime};
 use tracing::{error, info, warn};
 
-// cpal::Stream is not Send on all platforms; we control access via Mutex
-// The inner Stream is held purely for its RAII drop (stops recording).
-#[allow(dead_code)]
+// cpal::Stream is not Send on all platforms; we control access via Mutex.
+// We must explicitly pause() the inner stream to stop it — dropping alone is
+// not reliable on macOS/coreaudio.
 struct SendStream(Stream);
 unsafe impl Send for SendStream {}
 
@@ -102,6 +102,12 @@ impl Recorder {
             config.sample_format()
         );
 
+        // Defensively halt any pre-existing stream so we never accumulate
+        // concurrent writers on the shared buffer (see stop() for context).
+        if let Some(stream) = self.stream.take() {
+            let _ = stream.0.pause();
+        }
+
         let buffer = Arc::clone(&self.buffer);
         {
             let mut buf = buffer.lock().unwrap();
@@ -130,8 +136,16 @@ impl Recorder {
     }
 
     pub fn stop(&mut self) -> Result<AudioData> {
-        // Drop the stream to stop recording
-        self.stream.take();
+        // Explicitly pause before dropping. On macOS/coreaudio, dropping the
+        // cpal Stream does NOT reliably halt the input callback, leaving a
+        // "zombie" stream that keeps appending to the shared buffer. Each new
+        // recording would then add another concurrent writer, inflating the
+        // captured duration linearly and eventually causing ASR hallucination.
+        if let Some(stream) = self.stream.take() {
+            if let Err(e) = stream.0.pause() {
+                warn!("Failed to pause recording stream before drop: {}", e);
+            }
+        }
         info!("Recording stopped");
 
         let samples = {

--- a/src-tauri/src/audio/recorder.rs
+++ b/src-tauri/src/audio/recorder.rs
@@ -6,10 +6,23 @@ use tauri::{Manager, Runtime};
 use tracing::{error, info, warn};
 
 // cpal::Stream is not Send on all platforms; we control access via Mutex.
-// We must explicitly pause() the inner stream to stop it — dropping alone is
-// not reliable on macOS/coreaudio.
 struct SendStream(Stream);
 unsafe impl Send for SendStream {}
+
+// RAII guard: dropping a SendStream always pauses the underlying cpal stream
+// first. cpal's own Drop does NOT reliably halt the input callback on
+// macOS/coreaudio — without this explicit pause the stream becomes a "zombie"
+// that keeps appending to the shared buffer (inflating recording duration and
+// causing ASR hallucination) and holds the mic open (the OS "mic in use"
+// indicator never turns off). Putting it in Drop guarantees cleanup on every
+// path: stop(), stream replacement in start(), Recorder teardown, and panics.
+impl Drop for SendStream {
+    fn drop(&mut self) {
+        if let Err(e) = self.0.pause() {
+            warn!("Failed to pause recording stream on drop: {}", e);
+        }
+    }
+}
 
 pub struct AudioData {
     pub samples: Vec<f32>,
@@ -102,11 +115,10 @@ impl Recorder {
             config.sample_format()
         );
 
-        // Defensively halt any pre-existing stream so we never accumulate
-        // concurrent writers on the shared buffer (see stop() for context).
-        if let Some(stream) = self.stream.take() {
-            let _ = stream.0.pause();
-        }
+        // Defensively release any pre-existing stream so we never accumulate
+        // concurrent writers on the shared buffer. Dropping it pauses the cpal
+        // stream (see SendStream's Drop).
+        self.stream = None;
 
         let buffer = Arc::clone(&self.buffer);
         {
@@ -136,16 +148,10 @@ impl Recorder {
     }
 
     pub fn stop(&mut self) -> Result<AudioData> {
-        // Explicitly pause before dropping. On macOS/coreaudio, dropping the
-        // cpal Stream does NOT reliably halt the input callback, leaving a
-        // "zombie" stream that keeps appending to the shared buffer. Each new
-        // recording would then add another concurrent writer, inflating the
-        // captured duration linearly and eventually causing ASR hallucination.
-        if let Some(stream) = self.stream.take() {
-            if let Err(e) = stream.0.pause() {
-                warn!("Failed to pause recording stream before drop: {}", e);
-            }
-        }
+        // Release the stream; SendStream's Drop pauses the cpal stream, halting
+        // the input callback and releasing the mic. (cpal's own Drop is not
+        // enough on macOS/coreaudio — see SendStream's Drop impl.)
+        self.stream = None;
         info!("Recording stopped");
 
         let samples = {


### PR DESCRIPTION
Fixes #87.

## Summary
- `Recorder::stop()` stopped recording by dropping the cpal `Stream`. On macOS/coreaudio, dropping the input stream does **not** reliably halt the input callback, so the orphaned ("zombie") stream kept appending samples to the shared `Arc<Mutex<Vec<f32>>>` buffer.
- Each new `start()` clears the buffer but added another concurrent writer, so recording N was filled by N live streams → captured duration scaled ~N×. After ~3 recordings the inflated audio caused ASR hallucination, and since all providers share the single managed `Recorder`, every model was affected.
- Fix: explicitly `pause()` the stream before dropping it in `stop()`, and defensively pause any pre-existing stream in `start()`.

## Evidence (from app.log, 48 kHz mono → ratio should be ~1×)
| Recording | wall-clock | reported | ratio |
|---|---|---|---|
| 1 | ~15.1s | 60.4s | 4× |
| 2 | ~6.9s | 34.5s | 5× |
| 3 | ~13.6s | 81.7s | 6× |
| 4 | ~15.0s | 104.9s | 7× |
| 5 | ~18.4s | 147.4s | 8× |
| 6 | ~2.6s | 23.4s | 9× |

Multiplier increments by exactly +1 per recording — one leaked stream per cycle.

## Test plan
- [ ] `cargo build` (passes)
- [ ] Record several short clips in a row; confirm "Recorded N samples (X.Xs)" tracks real recording time (~1×) instead of growing
- [ ] Confirm transcription no longer degrades into hallucination after repeated recordings